### PR TITLE
feat: integrate AI-DLC INCEPTION phase for structured project planning

### DIFF
--- a/.kiro/prompts/inception.md
+++ b/.kiro/prompts/inception.md
@@ -1,0 +1,64 @@
+
+# INCEPTION — Structured Project Planning
+
+Run the full INCEPTION phase from AI-DLC: analyze workspace → gather requirements →
+write user stories → design architecture → generate GitHub issues.
+
+This is the entry point for new projects. After completion, the 8-agent pipeline takes over.
+
+## How to run
+
+Read `.kiro/skills/inception/SKILL.md` first, then load each reference file as you
+progress through the stages.
+
+## Stage 1: Workspace Detection (always)
+
+1. Read `references/workspace-detection.md` from the inception skill
+2. Scan the workspace
+3. Create `aidlc-docs/aidlc-state.md`
+4. Proceed to Stage 2
+
+## Stage 2: Requirements Analysis (always)
+
+1. Read `references/requirements-analysis.md`
+2. Read `references/depth-levels.md` to determine depth
+3. Analyze user's request
+4. If clarification needed, create question file per `references/question-format.md`
+5. Generate `aidlc-docs/inception/requirements/requirements.md`
+6. **Wait for user approval before proceeding**
+7. Append to `aidlc-docs/audit.md`
+
+## Stage 3: User Stories (conditional)
+
+1. Read `references/user-stories.md`
+2. Evaluate if stories add value (see skip conditions)
+3. If running: generate personas and stories
+4. **Wait for user approval**
+5. Append to audit
+
+## Stage 4: Architecture Design (conditional)
+
+1. Read `references/architecture-design.md`
+2. Evaluate if architecture design is needed
+3. If running: design components, tech stack, directory structure
+4. **Wait for user approval**
+5. Append to audit
+
+## Stage 5: Issue Generation (always)
+
+1. Read `references/issue-generation.md`
+2. Read all INCEPTION outputs generated so far
+3. Decompose into implementable, independent, testable issues
+4. Create issues via `gh issue create`
+5. Update `.kiro/steering/development-rules.md` with finalized tech stack
+6. Update `aidlc-docs/aidlc-state.md`
+7. Tell user to run `./scripts/start-pipeline.sh`
+
+## Rules
+
+- Each stage must append decisions to `aidlc-docs/audit.md` with ISO 8601 timestamps
+- User approval is required at stages 2, 3, 4 before proceeding
+- Stage 5 (issue generation) does NOT require approval — it auto-generates
+- Adapt depth based on complexity (minimal / standard / comprehensive)
+- Questions use file-based format, not inline chat
+- All documents go in `aidlc-docs/inception/`

--- a/.kiro/skills/inception/SKILL.md
+++ b/.kiro/skills/inception/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: inception
+description: >
+  AI-DLC INCEPTION phase: structured project planning workflow.
+  Workspace detection, requirements analysis, user stories, architecture design, and issue generation.
+  Use when starting a new project, planning features, or analyzing existing codebases.
+  Triggers on: new project, planning, requirements, architecture, design, brainstorm, inception.
+---
+
+# INCEPTION Phase — Adaptive Project Planning
+
+Structured planning workflow adapted from AI-DLC. Guides the user through
+requirements → design → issue generation, adapting depth to project complexity.
+
+## Workflow
+
+```
+1. Workspace Detection (always)
+2. Requirements Analysis (always, adaptive depth)
+3. User Stories (conditional)
+4. Architecture Design (conditional)
+5. Issue Generation (always) → feeds into 8-agent pipeline
+```
+
+## Detailed steps are in `references/` — read them on demand:
+
+- `references/workspace-detection.md`
+- `references/requirements-analysis.md`
+- `references/user-stories.md`
+- `references/architecture-design.md`
+- `references/issue-generation.md`
+- `references/depth-levels.md`
+- `references/question-format.md`

--- a/.kiro/skills/inception/references/architecture-design.md
+++ b/.kiro/skills/inception/references/architecture-design.md
@@ -1,0 +1,34 @@
+# Architecture Design (Conditional)
+
+## When to run
+- New components or services needed
+- System architecture decisions required
+- Multiple services or modules
+- Infrastructure design needed
+
+## When to skip
+- Changes within existing component boundaries
+- Simple feature additions to existing architecture
+
+## Steps
+
+### 1. Analyze context
+Read requirements and user stories (if generated).
+
+### 2. Design high-level architecture
+- Identify major components and responsibilities
+- Define component interfaces
+- Establish communication patterns (REST, WebSocket, events)
+- Choose technology stack (if not already decided)
+
+### 3. Design directory structure
+Based on project type, define the directory layout.
+
+### 4. Generate documents
+Create in `aidlc-docs/inception/architecture/`:
+- `architecture.md` — component diagram, responsibilities, interfaces
+- `technology-stack.md` — chosen technologies with rationale
+- `directory-structure.md` — project layout
+
+### 5. Get user approval
+Present architecture overview. User must confirm.

--- a/.kiro/skills/inception/references/depth-levels.md
+++ b/.kiro/skills/inception/references/depth-levels.md
@@ -1,0 +1,24 @@
+# Adaptive Depth Levels
+
+## Principle
+Depth refers to the level of detail within artifacts, adapting to problem complexity.
+
+## Levels
+
+### Minimal
+- Simple, well-understood changes
+- Clear requirements with no ambiguity
+- Single component affected
+- Output: brief intent analysis + direct issue generation
+
+### Standard
+- Normal complexity features
+- Some clarification needed
+- Multiple components affected
+- Output: requirements doc + user stories + architecture overview + issues
+
+### Comprehensive
+- Complex, high-risk changes
+- Multiple user types and workflows
+- New system or major redesign
+- Output: full requirements + detailed stories + architecture design + detailed issues

--- a/.kiro/skills/inception/references/issue-generation.md
+++ b/.kiro/skills/inception/references/issue-generation.md
@@ -1,0 +1,62 @@
+# Issue Generation (Always — Pipeline Handoff)
+
+This is the bridge between INCEPTION and the 8-agent pipeline.
+Converts design documents into GitHub issues that agents can pick up.
+
+## Steps
+
+### 1. Read all INCEPTION outputs
+- `aidlc-docs/inception/requirements/requirements.md`
+- `aidlc-docs/inception/user-stories/stories.md` (if exists)
+- `aidlc-docs/inception/architecture/` (if exists)
+
+### 2. Decompose into issues
+Each issue should be:
+- Implementable in a single PR
+- Independent (minimal dependencies between issues)
+- Testable (clear acceptance criteria)
+
+### 3. Prioritize
+1. Project setup / scaffolding (must be first)
+2. Core domain models / database schema
+3. Backend API endpoints
+4. Frontend pages / components
+5. Integration (frontend ↔ backend wiring)
+6. Testing (E2E, additional integration tests)
+7. Polish (UI, error handling, edge cases)
+8. Documentation
+
+### 4. Create issues
+For each issue:
+```bash
+gh issue create \
+  --title "feat: <concise description>" \
+  --body "## Description
+<what to implement>
+
+## Acceptance Criteria
+- [ ] <testable condition 1>
+- [ ] <testable condition 2>
+
+## Technical Notes
+<relevant architecture decisions, file paths, dependencies>
+
+## References
+- Requirements: aidlc-docs/inception/requirements/requirements.md
+- Architecture: aidlc-docs/inception/architecture/architecture.md" \
+  --label "<appropriate label>"
+```
+
+### 5. Update steering
+Write the finalized tech stack and project conventions to
+`.kiro/steering/development-rules.md` (project-specific section).
+
+### 6. Update state
+Update `aidlc-docs/aidlc-state.md`:
+```
+- Current phase: INCEPTION ✅ → CONSTRUCTION (via pipeline)
+- Issues created: <count>
+```
+
+### 7. Instruct user
+Tell the user to run `./scripts/start-pipeline.sh` to launch the 8-agent pipeline.

--- a/.kiro/skills/inception/references/question-format.md
+++ b/.kiro/skills/inception/references/question-format.md
@@ -1,0 +1,26 @@
+# Question Format
+
+## Rules
+- All questions go in a dedicated file, not inline chat
+- Use multiple-choice format with an "Other" option
+- File naming: `{stage}-questions.md`
+- Location: `aidlc-docs/inception/{stage}/`
+
+## Format
+```markdown
+## Question [number]
+[Clear, specific question]
+
+A) [First option]
+B) [Second option]
+C) [Third option]
+X) Other (describe below)
+
+[Answer]:
+```
+
+## Guidelines
+- Minimum 2 meaningful options + Other
+- Don't create filler options
+- Each question should resolve a specific ambiguity
+- Group related questions together

--- a/.kiro/skills/inception/references/requirements-analysis.md
+++ b/.kiro/skills/inception/references/requirements-analysis.md
@@ -1,0 +1,39 @@
+# Requirements Analysis (Adaptive)
+
+Always runs. Depth adapts to complexity.
+
+## Adaptive Depth
+
+| Level | When | What |
+|-------|------|------|
+| Minimal | Simple, clear request | Intent analysis only |
+| Standard | Normal complexity | Functional + non-functional requirements |
+| Comprehensive | Complex, high-risk | Full requirements with traceability |
+
+## Steps
+
+### 1. Analyze user request (Intent Analysis)
+- What is the user trying to build?
+- What problem does it solve?
+- Who are the target users?
+- What are the success criteria?
+
+### 2. Determine depth
+Based on: number of features, integrations, user types, risk level.
+
+### 3. Ask clarification questions
+Use question file format (see `question-format.md`).
+Create `aidlc-docs/inception/requirements/requirements-questions.md`.
+
+### 4. Generate requirements document
+Create `aidlc-docs/inception/requirements/requirements.md`:
+- Functional requirements (grouped by feature area)
+- Non-functional requirements (performance, security, scalability)
+- Constraints and assumptions
+- Out of scope
+
+### 5. Get user approval
+Present requirements summary. User must confirm before proceeding.
+
+### 6. Record in audit
+Append to `aidlc-docs/audit.md` with timestamp.

--- a/.kiro/skills/inception/references/user-stories.md
+++ b/.kiro/skills/inception/references/user-stories.md
@@ -1,0 +1,32 @@
+# User Stories (Conditional)
+
+## When to run
+- New user-facing features
+- Changes affecting user workflows
+- Multiple user types involved
+- Complex business requirements
+
+## When to skip
+- Pure internal refactoring
+- Simple bug fixes with clear scope
+- Infrastructure-only changes
+- Documentation-only updates
+
+## Steps
+
+### 1. Identify personas
+Based on requirements, identify distinct user types.
+
+### 2. Write stories
+Format: "As a [persona], I want to [action] so that [benefit]"
+
+Each story includes:
+- Acceptance criteria (testable conditions)
+- Priority (must-have / should-have / nice-to-have)
+- Estimated complexity (S/M/L/XL)
+
+### 3. Generate document
+Create `aidlc-docs/inception/user-stories/stories.md` and `personas.md`.
+
+### 4. Get user approval
+Present stories grouped by persona. User must confirm.

--- a/.kiro/skills/inception/references/workspace-detection.md
+++ b/.kiro/skills/inception/references/workspace-detection.md
@@ -1,0 +1,34 @@
+# Workspace Detection
+
+## Purpose
+Determine workspace state and project type before planning.
+
+## Steps
+
+### 1. Check for existing project state
+- Look for `aidlc-docs/aidlc-state.md` — if found, resume from last phase
+- Look for existing `issue/task.md` — if found, check current status
+
+### 2. Scan workspace for existing code
+- Scan for source files (.ts, .tsx, .py, .java, .go, .rs, etc.)
+- Check for build files (package.json, pyproject.toml, Cargo.toml, etc.)
+- Check for infrastructure (Dockerfile, terraform/, CDK, etc.)
+
+### 3. Classify project
+- **Greenfield**: No existing code → full planning needed
+- **Brownfield**: Existing code → analyze before planning
+
+### 4. Record findings
+Create `aidlc-docs/aidlc-state.md`:
+```markdown
+# Project State
+- Type: greenfield / brownfield
+- Detected stack: [languages, frameworks]
+- Workspace root: [path]
+- Current phase: INCEPTION
+- Current stage: workspace-detection ✅
+```
+
+### 5. Proceed
+- Brownfield → read existing code structure before requirements
+- Greenfield → proceed to requirements analysis

--- a/.kiro/steering/development-rules.md
+++ b/.kiro/steering/development-rules.md
@@ -3,15 +3,16 @@ name: development-rules
 description: 全コーディングタスクに適用される汎用開発ルール
 ---
 
-## 初回セットアップ
+## Initial Setup
 
-「プロジェクト固有の設定」セクションが空（コメントアウトのみ）の場合：
-1. `.kiro/prompts/brainstorming.md` を読んでブレインストーミングを開始する
-2. 設計が固まったら「プロジェクト固有の設定」セクションに技術スタック等を書き込む
-3. `.kiro/prompts/create-issue.md` を読んでissueを作成する
-4. 完了後 `./scripts/start-pipeline.sh` の実行を案内する
+If the "Project-specific settings" section below is empty (comments only):
+1. Read `.kiro/skills/inception/SKILL.md` and run the INCEPTION workflow
+2. Guide the user through: workspace detection → requirements → stories → architecture
+3. After design is finalized, write tech stack to the "Project-specific settings" section
+4. Generate GitHub issues via `gh issue create`
+5. Instruct user to run `./scripts/start-pipeline.sh`
 
-記載済みの場合はこのセクションを無視してよい。
+If settings are already filled in, skip this section.
 
 ## プロジェクト固有の設定
 
@@ -228,3 +229,43 @@ PRは以下を全て満たさないとマージしない:
 - issue/PRのコメントは全て英語で書く
 - レビュー結果（🔴/🟢）はPRコメントに投稿する
 - エスカレーション（3回失敗等）もPRコメントで人間に通知する
+
+## Audit Trail
+
+All design decisions and approvals are recorded in `aidlc-docs/audit.md`.
+
+- Append-only — never overwrite existing entries
+- Each entry includes ISO 8601 timestamp, stage name, user input, and AI response
+- Record all user approvals and rejections
+- Record all issue creation events
+
+Format:
+```markdown
+## [Stage Name]
+**Timestamp**: YYYY-MM-DDTHH:MM:SSZ
+**User Input**: "[exact user input]"
+**AI Response**: "[action taken]"
+**Context**: [stage, decision, or artifact created]
+---
+```
+
+## Document Structure
+
+INCEPTION phase generates documents in `aidlc-docs/`:
+
+```
+aidlc-docs/
+├── aidlc-state.md                    # Project state tracking
+├── audit.md                          # Decision audit trail
+└── inception/
+    ├── requirements/
+    │   ├── requirements.md           # Functional + non-functional
+    │   └── requirements-questions.md # Clarification Q&A
+    ├── user-stories/
+    │   ├── stories.md                # User stories with acceptance criteria
+    │   └── personas.md               # User personas
+    └── architecture/
+        ├── architecture.md           # Component diagram + responsibilities
+        ├── technology-stack.md       # Tech choices with rationale
+        └── directory-structure.md    # Project layout
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,15 @@
 # Kiro Engineer Teams
 
-8-agent parallel development pipeline template.
+8-agent parallel development pipeline with AI-DLC INCEPTION planning.
 
 ## First interaction
 
-Tell me what you want to build. Brainstorming starts automatically.
+Tell me what you want to build. The INCEPTION workflow starts automatically:
+1. Workspace detection → analyze existing code (if any)
+2. Requirements analysis → clarify what to build
+3. User stories → define user-facing behavior (if needed)
+4. Architecture design → choose tech stack and structure (if needed)
+5. Issue generation → create GitHub issues for the pipeline
 
 ## Rules
 
@@ -14,9 +19,8 @@ All rules are in `.kiro/steering/development-rules.md`. Key points:
 - Git: worktree isolation, Conventional Commits (English), squash merge
 - PR comments and issues: always in English
 - Parallel agents: check `issue/task.md` before starting work
+- Audit trail: all decisions recorded in `aidlc-docs/audit.md`
 
-## After brainstorming
+## After INCEPTION
 
-1. Tech stack and conventions are written to steering
-2. Issues are created via `gh issue create`
-3. Run `./scripts/start-pipeline.sh` to launch 8-agent pipeline
+Run `./scripts/start-pipeline.sh` to launch 8-agent pipeline in zellij.

--- a/scripts/start-pipeline.sh
+++ b/scripts/start-pipeline.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # 8-Agent Pipeline Launcher
 #
-# Phase 1: Brainstorm — design with user → create issues
+# Phase 1: INCEPTION — structured planning with AI-DLC workflow
 # Phase 2: Pipeline — launch 8 agents in zellij
 #
 # Usage: ./scripts/start-pipeline.sh
@@ -33,8 +33,9 @@ if ! gh auth status &>/dev/null; then
   exit 1
 fi
 
-# ── Ensure task.md ──
-mkdir -p issue
+# ── Ensure directories ──
+mkdir -p issue aidlc-docs/inception
+
 if [[ ! -f "issue/task.md" ]]; then
   cat > issue/task.md << 'TMPL'
 # Issue Tracker
@@ -45,24 +46,25 @@ if [[ ! -f "issue/task.md" ]]; then
 TMPL
 fi
 
-# ── Phase 1: Brainstorm ──
+# ── Phase 1: INCEPTION ──
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  Phase 1: Brainstorming"
+echo "  Phase 1: INCEPTION (AI-DLC)"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
-echo "  Kiro CLI will start."
-echo "  Tell it what you want to build."
-echo "  After design is finalized, issues will be created."
-echo "  Type /quit to exit and launch the pipeline."
+echo "  Kiro CLI will start with the INCEPTION workflow."
+echo "  This guides you through:"
 echo ""
-echo "  Tips:"
-echo "    - /brainstorming starts the design flow"
-echo "    - /create-issue creates issues from the design"
-echo "    - /quit exits to launch the pipeline"
+echo "    1. Workspace Detection"
+echo "    2. Requirements Analysis"
+echo "    3. User Stories (if needed)"
+echo "    4. Architecture Design (if needed)"
+echo "    5. Issue Generation (automatic)"
+echo ""
+echo "  After issues are created, type /quit to launch the pipeline."
 echo ""
 read -p "  Press Enter to start → " _
 
-kiro-cli chat
+kiro-cli chat --trust-all-tools "/inception"
 
 # ── Check issues exist ──
 ISSUE_COUNT=$(gh issue list --state open --json number --jq 'length' 2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary

Integrate AI-DLC's INCEPTION phase into the template, customized for the 8-agent pipeline.

### What's added

**Inception skill** (`.kiro/skills/inception/`)
- `SKILL.md` — skill metadata with trigger keywords
- `references/workspace-detection.md` — scan workspace, classify greenfield/brownfield
- `references/requirements-analysis.md` — adaptive depth requirements gathering
- `references/user-stories.md` — conditional user story generation
- `references/architecture-design.md` — component design, tech stack, directory structure
- `references/issue-generation.md` — **bridge to pipeline**: converts design docs into GitHub issues
- `references/depth-levels.md` — minimal/standard/comprehensive depth guide
- `references/question-format.md` — structured question file format

**Inception prompt** (`.kiro/prompts/inception.md`)
- 5-stage workflow: workspace detection → requirements → stories → architecture → issues
- User approval gates at stages 2, 3, 4
- Auto-generates issues at stage 5 (no approval needed)

**Steering updates**
- Initial setup now triggers INCEPTION instead of brainstorming
- Audit trail rules (`aidlc-docs/audit.md`)
- Document structure (`aidlc-docs/inception/`)

**Pipeline integration**
- `start-pipeline.sh` Phase 1 now runs `/inception`
- `AGENTS.md` references INCEPTION workflow

### Flow
```
./scripts/start-pipeline.sh
  → Phase 1: /inception (human + AI collaborate on design)
    → workspace detection → requirements → stories → architecture
    → auto-generate GitHub issues
  → Phase 2: zellij 8-agent pipeline picks up issues
```