### PR TITLE
docs: add install commands to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,15 @@ Agent 8: /auto-dependabot (dependency updates, separate lane)
 
 ## 📋 Prerequisites
 
-| Tool | Required |
-|------|----------|
-| [Kiro CLI](https://kiro.dev/docs/cli/) | ✅ |
-| [zellij](https://zellij.dev/) | ✅ |
-| [GitHub CLI](https://cli.github.com/) | ✅ authenticated (`gh auth login`) |
-| git remote | ✅ configured |
+| Tool | Install | Required |
+|------|---------|----------|
+| [Kiro CLI](https://kiro.dev/docs/cli/) | See [downloads](https://kiro.dev/downloads/) | ✅ |
+| [zellij](https://zellij.dev/) | `brew install zellij` | ✅ |
+| [GitHub CLI](https://cli.github.com/) | `brew install gh` → `gh auth login` | ✅ |
+| [just](https://just.systems/) | `brew install just` | Optional (for GitLab switch) |
+
+> **Linux**: Replace `brew install` with your package manager or see each tool's install docs.
+> **Windows**: Use WSL2 or see each tool's Windows install docs.
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -105,12 +105,15 @@ Agent 8: /auto-dependabot（依存更新、別レーン）
 
 ## 📋 前提条件
 
-| ツール | 必須 |
-|--------|------|
-| [Kiro CLI](https://kiro.dev/docs/cli/) | ✅ |
-| [zellij](https://zellij.dev/) | ✅ |
-| [GitHub CLI](https://cli.github.com/) | ✅ 認証済み (`gh auth login`) |
-| git remote | ✅ 設定済み |
+| ツール | インストール | 必須 |
+|--------|------------|------|
+| [Kiro CLI](https://kiro.dev/docs/cli/) | [ダウンロード](https://kiro.dev/downloads/) | ✅ |
+| [zellij](https://zellij.dev/) | `brew install zellij` | ✅ |
+| [GitHub CLI](https://cli.github.com/) | `brew install gh` → `gh auth login` | ✅ |
+| [just](https://just.systems/) | `brew install just` | 任意（GitLab切替用） |
+
+> **Linux**: `brew install` の代わりに各ツールのインストールドキュメントを参照。
+> **Windows**: WSL2を使用するか、各ツールのWindowsインストールドキュメントを参照。
 
 ---
 


### PR DESCRIPTION
Add install commands (brew install) for zellij, gh, and just to the prerequisites table in both English and Japanese READMEs. Include notes for Linux and Windows users.