### PR TITLE
docs: split Quick Start into new project vs existing project

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,42 @@ issue → implementation → review → merge → E2E verification — fully aut
 
 ## Quick Start
 
+### A. New project (start from scratch)
+
 ```bash
-# 1. Clone the template
-git clone https://github.com/yoshimi-I/kiro-engineer-teams.git my-app
+# 1. Create project from template (no git history)
+npx degit yoshimi-I/kiro-engineer-teams my-app
 cd my-app
 
-# 2. Install prerequisites (one command)
+# 2. Install prerequisites
 ./scripts/setup.sh
 
-# 3. Point to your own repo
-git remote set-url origin <your-repo-url>
-git push -u origin main
+# 3. Initialize git and create GitHub repo
+git init
+gh repo create my-app --public --source=. --push
 
-# 4. Start the full pipeline (INCEPTION → 8-agent automation)
+# 4. Start (INCEPTION → 8-agent pipeline)
 ./scripts/start-pipeline.sh
 ```
+
+### B. Add to existing project
+
+```bash
+cd /path/to/your-project
+
+# 1. Copy .kiro/, scripts/, AGENTS.md
+npx degit yoshimi-I/kiro-engineer-teams .kiro-tmp
+cp -r .kiro-tmp/.kiro .kiro-tmp/scripts .kiro-tmp/AGENTS.md .
+rm -rf .kiro-tmp
+
+# 2. Install prerequisites (skips already installed)
+./scripts/setup.sh
+
+# 3. Start
+./scripts/start-pipeline.sh
+```
+
+> 💡 You can also use GitHub's **"Use this template"** button to create a new repo directly.
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -18,21 +18,42 @@ issue → 実装 → レビュー → マージ → E2E検証を全自動化。
 
 ## クイックスタート
 
+### A. 新規プロジェクト（ゼロから始める）
+
 ```bash
-# 1. テンプレートをクローン
-git clone https://github.com/yoshimi-I/kiro-engineer-teams.git my-app
+# 1. テンプレートからプロジェクト作成（git履歴なし）
+npx degit yoshimi-I/kiro-engineer-teams my-app
 cd my-app
 
-# 2. 前提ツールを一括インストール
+# 2. 前提ツールをインストール
 ./scripts/setup.sh
 
-# 3. 自分のリポジトリに切り替え
-git remote set-url origin <your-repo-url>
-git push -u origin main
+# 3. gitを初期化してGitHubリポジトリを作成
+git init
+gh repo create my-app --public --source=. --push
 
-# 4. パイプライン起動（INCEPTION → 8エージェント自動化）
+# 4. 起動（INCEPTION → 8エージェントパイプライン）
 ./scripts/start-pipeline.sh
 ```
+
+### B. 既存プロジェクトに追加
+
+```bash
+cd /path/to/your-project
+
+# 1. .kiro/, scripts/, AGENTS.md をコピー
+npx degit yoshimi-I/kiro-engineer-teams .kiro-tmp
+cp -r .kiro-tmp/.kiro .kiro-tmp/scripts .kiro-tmp/AGENTS.md .
+rm -rf .kiro-tmp
+
+# 2. 前提ツールをインストール（インストール済みはスキップ）
+./scripts/setup.sh
+
+# 3. 起動
+./scripts/start-pipeline.sh
+```
+
+> 💡 GitHubの **「Use this template」** ボタンから直接リポジトリを作成することもできます。
 
 ---
 


### PR DESCRIPTION
## Summary

Split Quick Start into two clear paths:

**A. New project** — `npx degit` (no git history) → setup → git init → gh repo create → start
**B. Existing project** — copy .kiro/ + scripts/ + AGENTS.md → setup → start

Also mention GitHub's "Use this template" button as an alternative.

Fixes the issue where `git clone` would bring all template commit history into the user's project.