### PR TITLE
fix: enable mouse_mode in zellij pipeline layout

### DIFF
--- a/scripts/pipeline.kdl
+++ b/scripts/pipeline.kdl
@@ -1,3 +1,5 @@
+mouse_mode true
+
 layout {
     tab name="Pipeline" {
         pane split_direction="horizontal" {


### PR DESCRIPTION
zellijのペインクリック移動が効かない環境向けに mouse_mode true を pipeline.kdl に追加。