### PR TITLE
chore: add GitHub templates and gitignore issue/task.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- OS:
+- Node.js:
+- Browser (if applicable):
+
+## Additional Context
+
+Any other context, screenshots, or logs.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "feat: "
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+A clear description of the feature.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed Solution
+
+How should this be implemented?
+
+## Alternatives Considered
+
+Any alternative approaches you've considered.
+
+## Additional Context
+
+Any other context, mockups, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Related Issue
+
+closes #
+
+## Changes
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Lint/format passed
+- [ ] No breaking changes (or documented)

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 aidlc-docs/
+issue/task.md

--- a/issue/task.md
+++ b/issue/task.md
@@ -1,5 +1,0 @@
-# Issue Tracker
-
-| Issue | Title | Status | Branch |
-|-------|-------|--------|--------|
-| #999 | (example) feat: add feature | in-progress / in-review / merged / resolved | feat/issue-999-xxx |


### PR DESCRIPTION
## Changes

- Add ISSUE_TEMPLATE (bug report, feature request)
- Add PULL_REQUEST_TEMPLATE
- Add `issue/task.md` to `.gitignore` to prevent conflicts between users
- Remove `issue/task.md` from git tracking (file stays local)