### PR TITLE
feat: add install script for existing projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ just start
 
 ---
 
+## 📥 Add to Existing Project
+
+Already have a project? Run this one-liner from your project root:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/install.sh)
+```
+
+This copies `.kiro/`, `scripts/`, `justfile`, `AGENTS.md`, and `skills-lock.json` into your project. Existing files are never overwritten.
+
+Then:
+```bash
+just setup   # install prerequisites
+just start   # start INCEPTION + pipeline
+```
+
+---
+
 ## 🔄 Full Flow
 
 ```

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -44,6 +44,24 @@ just start
 
 ---
 
+## 📥 既存プロジェクトへの導入
+
+既にプロジェクトがある場合、プロジェクトルートでこのワンライナーを実行：
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/install.sh)
+```
+
+`.kiro/`、`scripts/`、`justfile`、`AGENTS.md`、`skills-lock.json` がコピーされます。既存ファイルは上書きされません。
+
+その後：
+```bash
+just setup   # 前提ツールをインストール
+just start   # INCEPTION + パイプライン起動
+```
+
+---
+
 ## 🔄 全体フロー
 
 ```

--- a/justfile
+++ b/justfile
@@ -4,6 +4,10 @@
 init:
     ./scripts/init.sh
 
+# Install into existing project (run from target project root)
+install:
+    bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/install.sh)
+
 # Install prerequisites
 setup:
     ./scripts/setup.sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Install kiro-engineer-teams into an existing project.
+# Usage: curl -fsSL <raw-url>/scripts/install.sh | bash
+#    or: bash <(curl -fsSL <raw-url>/scripts/install.sh)
+
+set -euo pipefail
+
+REPO="yoshimi-I/kiro-engineer-teams"
+BRANCH="main"
+BOLD='\033[1m' DIM='\033[2m' GREEN='\033[32m' RED='\033[31m' YELLOW='\033[33m' RESET='\033[0m'
+
+info()  { echo -e "${GREEN}  ✔ $1${RESET}"; }
+warn()  { echo -e "${YELLOW}  ⚠ $1${RESET}"; }
+fail()  { echo -e "${RED}  ✗ $1${RESET}"; exit 1; }
+
+echo ""
+echo -e "${BOLD}  📦 Install kiro-engineer-teams${RESET}"
+echo -e "${DIM}  Add 8-agent pipeline to your existing project${RESET}"
+echo ""
+
+# ── Preflight ──
+[[ ! -d ".git" ]] && fail "Not a git repository. Run from your project root."
+
+# ── Clone to temp dir ──
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+git clone --depth 1 --branch "$BRANCH" "https://github.com/${REPO}.git" "$TMPDIR" 2>/dev/null
+
+# ── Copy files ──
+copy_dir() {
+  local src="$TMPDIR/$1"
+  [[ ! -d "$src" ]] && return
+  if [[ -d "$1" ]]; then
+    warn "$1/ already exists — merging (won't overwrite existing files)"
+    cp -rn "$src" "$(dirname "$1")/"
+  else
+    cp -r "$src" "$1"
+    info "$1/"
+  fi
+}
+
+copy_file() {
+  local src="$TMPDIR/$1"
+  [[ ! -f "$src" ]] && return
+  if [[ -f "$1" ]]; then
+    warn "$1 already exists — skipped"
+  else
+    mkdir -p "$(dirname "$1")"
+    cp "$src" "$1"
+    info "$1"
+  fi
+}
+
+echo -e "${BOLD}  Copying files...${RESET}"
+echo ""
+
+copy_dir ".kiro"
+copy_dir "scripts"
+copy_file "justfile"
+copy_file "AGENTS.md"
+copy_file "skills-lock.json"
+
+# Make scripts executable
+chmod +x scripts/*.sh 2>/dev/null || true
+
+echo ""
+echo -e "${GREEN}  ✔ Installation complete!${RESET}"
+echo ""
+echo -e "  Next steps:"
+echo -e "    ${DIM}1.${RESET} just setup  ${DIM}# install prerequisites${RESET}"
+echo -e "    ${DIM}2.${RESET} just start  ${DIM}# start INCEPTION + pipeline${RESET}"
+echo ""


### PR DESCRIPTION
## What

Add a one-liner install flow for existing projects.

## Changes

- `scripts/install.sh` — curl-executable script that copies `.kiro/`, `scripts/`, `justfile`, `AGENTS.md`, `skills-lock.json` into the current project (never overwrites existing files)
- README.md / docs/README.ja.md — "Add to Existing Project" section added after Quick Start
- `justfile` — `just install` command added

## Usage

```bash
bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/install.sh)
just setup
just start
```