### PR TITLE
fix: improve install script reliability and cross-platform support

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,12 +26,12 @@ test-layout:
 
 # Switch to Japanese
 ja:
-    @sed -i '' 's/Always respond to the user in English\./Always respond to the user in Japanese./' .kiro/steering/development-rules.md
-    @sed -i '' 's/Always respond in English\./Always respond in Japanese./' AGENTS.md
+    @scripts/sed-i.sh 's/Always respond to the user in English\./Always respond to the user in Japanese./' .kiro/steering/development-rules.md
+    @scripts/sed-i.sh 's/Always respond in English\./Always respond in Japanese./' AGENTS.md
     @echo "✅ Switched to Japanese"
 
 # Switch to English
 en:
-    @sed -i '' 's/Always respond to the user in Japanese\./Always respond to the user in English./' .kiro/steering/development-rules.md
-    @sed -i '' 's/Always respond in Japanese\./Always respond in English./' AGENTS.md
+    @scripts/sed-i.sh 's/Always respond to the user in Japanese\./Always respond to the user in English./' .kiro/steering/development-rules.md
+    @scripts/sed-i.sh 's/Always respond in Japanese\./Always respond in English./' AGENTS.md
     @echo "✅ Switched to English"

--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -82,10 +82,10 @@ while true; do
   cycle=$((cycle + 1))
   echo "━━━ Cycle #${cycle} [$(date '+%H:%M:%S')] ━━━"
 
-  # Pass prompt via stdin to avoid ARG_MAX limits
-  if cat "$PROMPT_FILE" | kiro-cli chat \
+  if kiro-cli chat \
     --no-interactive \
-    --trust-all-tools 2>&1; then
+    --trust-all-tools \
+    "$(cat "$PROMPT_FILE")" 2>&1; then
     error_count=0
     echo "✅ Cycle #${cycle} complete"
   else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,17 +22,17 @@ echo ""
 [[ ! -d ".git" ]] && fail "Not a git repository. Run from your project root."
 
 # ── Clone to temp dir ──
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
-git clone --depth 1 --branch "$BRANCH" "https://github.com/${REPO}.git" "$TMPDIR" 2>/dev/null
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+git clone --depth 1 --branch "$BRANCH" "https://github.com/${REPO}.git" "$WORK_DIR" 2>/dev/null
 
-# ── Copy files ──
+# ── Copy helpers ──
 copy_dir() {
-  local src="$TMPDIR/$1"
+  local src="$WORK_DIR/$1"
   [[ ! -d "$src" ]] && return
   if [[ -d "$1" ]]; then
     warn "$1/ already exists — merging (won't overwrite existing files)"
-    cp -rn "$src" "$(dirname "$1")/"
+    rsync -a --ignore-existing "$src/" "$1/"
   else
     cp -r "$src" "$1"
     info "$1/"
@@ -40,7 +40,7 @@ copy_dir() {
 }
 
 copy_file() {
-  local src="$TMPDIR/$1"
+  local src="$WORK_DIR/$1"
   [[ ! -f "$src" ]] && return
   if [[ -f "$1" ]]; then
     warn "$1 already exists — skipped"
@@ -56,8 +56,73 @@ echo ""
 
 copy_dir ".kiro"
 copy_dir "scripts"
-copy_file "justfile"
-copy_file "AGENTS.md"
+
+# ── Merge justfile recipes ──
+RECIPES=("setup" "start" "pipeline" "test-layout" "ja" "en")
+RECIPE_BLOCKS=$(cat <<'JUST'
+
+# ── kiro-engineer-teams ──
+
+# Install prerequisites
+setup:
+    ./scripts/setup.sh
+
+# Start full pipeline (INCEPTION → 7-agent)
+start:
+    ./scripts/start-pipeline.sh
+
+# Launch 7-agent pipeline only (skip INCEPTION)
+pipeline:
+    zellij --layout scripts/pipeline.kdl
+
+# Test zellij 8-pane layout
+test-layout:
+    ./scripts/test-layout.sh
+
+# Switch to Japanese
+ja:
+    @scripts/sed-i.sh 's/Always respond to the user in English\./Always respond to the user in Japanese./' .kiro/steering/development-rules.md
+    @scripts/sed-i.sh 's/Always respond in English\./Always respond in Japanese./' AGENTS.md
+    @echo "✅ Switched to Japanese"
+
+# Switch to English
+en:
+    @scripts/sed-i.sh 's/Always respond to the user in Japanese\./Always respond to the user in English./' .kiro/steering/development-rules.md
+    @scripts/sed-i.sh 's/Always respond in Japanese\./Always respond in English./' AGENTS.md
+    @echo "✅ Switched to English"
+JUST
+)
+
+if [[ -f "justfile" ]]; then
+  missing=false
+  for r in "${RECIPES[@]}"; do
+    grep -q "^${r}:" "justfile" || { missing=true; break; }
+  done
+  if $missing; then
+    echo "$RECIPE_BLOCKS" >> "justfile"
+    info "justfile — appended pipeline recipes"
+  else
+    info "justfile — all recipes already present"
+  fi
+else
+  cp "$WORK_DIR/justfile" "justfile"
+  info "justfile"
+fi
+
+# ── Merge AGENTS.md ──
+AGENTS_MARKER="## After INCEPTION"
+if [[ -f "AGENTS.md" ]]; then
+  if ! grep -q "$AGENTS_MARKER" "AGENTS.md"; then
+    cat "$WORK_DIR/AGENTS.md" >> "AGENTS.md"
+    info "AGENTS.md — appended pipeline config"
+  else
+    info "AGENTS.md — already configured"
+  fi
+else
+  cp "$WORK_DIR/AGENTS.md" "AGENTS.md"
+  info "AGENTS.md"
+fi
+
 copy_file "skills-lock.json"
 
 # Make scripts executable

--- a/scripts/sed-i.sh
+++ b/scripts/sed-i.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Cross-platform sed -i wrapper (macOS + Linux)
+if sed --version 2>/dev/null | grep -q GNU; then
+  sed -i "$@"
+else
+  sed -i '' "$@"
+fi


### PR DESCRIPTION
## Changes

- **justfile merge**: Append pipeline recipes to existing justfile instead of skipping
- **AGENTS.md merge**: Append config if marker missing instead of skipping
- **Cross-platform sed**: Add `scripts/sed-i.sh` wrapper for macOS + Linux compatibility
- **TMPDIR rename**: Use `WORK_DIR` to avoid overwriting system env var
- **rsync**: Replace `cp -rn` with `rsync --ignore-existing` for reliable dir merge
- **agent.sh**: Pass prompt as argument instead of stdin pipe