### PR TITLE
fix: add /quit exit instruction and replace watch with loop

### DIFF
--- a/scripts/pipeline.kdl
+++ b/scripts/pipeline.kdl
@@ -44,7 +44,7 @@ layout {
     }
     tab name="Status" {
         pane command="bash" name="task.md" {
-            args "-c" "watch -n 5 'cat issue/task.md 2>/dev/null || echo No task.md yet'"
+            args "-c" "while true; do clear; cat issue/task.md 2>/dev/null || echo 'No task.md yet'; sleep 5; done"
         }
     }
 }

--- a/scripts/start-pipeline.sh
+++ b/scripts/start-pipeline.sh
@@ -62,6 +62,9 @@ echo "    5. Issue Generation (automatic)"
 echo ""
 echo "  After issues are created, type /quit to launch the pipeline."
 echo ""
+echo "  ⚠️  INCEPTION が完了したら /quit と入力してこの画面を抜けてください。"
+echo "      パイプラインが自動で起動します。"
+echo ""
 read -p "  Press Enter to start → " _
 
 kiro-cli chat --trust-all-tools "/inception"


### PR DESCRIPTION
- Add Japanese /quit instruction to INCEPTION phase message
- Replace `watch` command with `while/clear/cat/sleep` loop in pipeline.kdl for macOS compatibility