### PR TITLE
fix: add keybinds to locked mode in pipeline.kdl

### DIFF
--- a/scripts/pipeline.kdl
+++ b/scripts/pipeline.kdl
@@ -1,6 +1,12 @@
 mouse_mode true
 
 keybinds {
+    locked {
+        bind "Ctrl h" { MoveFocus "Left"; }
+        bind "Ctrl j" { MoveFocus "Down"; }
+        bind "Ctrl k" { MoveFocus "Up"; }
+        bind "Ctrl l" { MoveFocus "Right"; }
+    }
     normal {
         bind "Ctrl h" { MoveFocus "Left"; }
         bind "Ctrl j" { MoveFocus "Down"; }


### PR DESCRIPTION
Ctrl+h/j/k/l were only bound in `normal` mode. When panes run commands, zellij can be in `locked` mode, making the keybinds unresponsive. Added same bindings to `locked` mode.