### PR TITLE
fix: fix-reviewのPR検出改善とマージ待ちPR自動処理

### DIFF
--- a/.kiro/prompts/fix-review-issues.md
+++ b/.kiro/prompts/fix-review-issues.md
@@ -6,15 +6,22 @@
 ## 1サイクルの処理
 
 ### Step 1: 修正が必要なPRを検出
+
+まず `reviewDecision` で CHANGES_REQUESTED のPRを検出する:
 ```bash
-gh pr list --json number,title,headRefName --limit 20
+gh pr list --json number,title,headRefName,reviewDecision --limit 20
 ```
-各PRのコメントを確認:
+`reviewDecision` が `CHANGES_REQUESTED` のPRを対象にする。
+
+次に、対象PRのレビューコメントとPRコメントの両方から指摘内容を取得する:
 ```bash
-gh pr view <number> --comments --json comments
+gh pr view <number> --json reviews,comments
 ```
-「🔴 修正必須」または「🔴 マージ失敗」を含むコメントがあるPRを対象にする。
-対象がなければ「監視継続中。」で2分待機→再チェック。
+「🔴 修正必須」または「🔴 マージ失敗」を含むレビュー/コメントから指摘を抽出する。
+
+**重要**: `reviewDecision` が `CHANGES_REQUESTED` であれば、コメント内に「🔴 修正必須」の文字列がなくても修正対象とする。レビュー本文（reviews）にも指摘が含まれている場合があるため、comments だけでなく reviews も必ず確認すること。
+
+対象がなければ「監視継続中。」で終了（次サイクルで再チェック）。
 
 ### Step 2: 指摘内容の取得と理解
 
@@ -71,9 +78,27 @@ gh pr view <number> --json reviewDecision --jq '.reviewDecision'
 
 | 条件 | 動作 |
 |------|------|
-| 修正必要PRが0件 | 2分待機して再チェック（常駐） |
+| 修正必要PRが0件 | APPROVEDでマージ待ちのPRを探してマージ（後述）→ 終了 |
 | ユーザーが「止めて」と言った | 即座に停止 |
 | 同じPRで3回修正しても🔴が残る | PRにコメントして人間にエスカレーション |
+
+## 修正対象がない場合: マージ待ちPRの処理
+
+修正が必要なPRが0件の場合、APPROVEDでまだマージされていないPRを探して積極的にマージする。
+
+```bash
+gh pr list --json number,title,headRefName,reviewDecision --limit 20
+```
+
+`reviewDecision` が `APPROVED` のPRがあれば:
+```bash
+gh pr merge <number> --squash --delete-branch
+```
+
+マージ失敗時はコメントしてリベース対応:
+```bash
+gh pr comment <number> --body "🔴 マージ失敗: コンフリクトが発生。リベースが必要です。"
+```
 
 ## ルール
 


### PR DESCRIPTION
## 変更内容

### PR検出の改善
- `reviewDecision: CHANGES_REQUESTED` を第一の検出手段に変更
- `reviews` と `comments` の両方から指摘を抽出（レビューボディの見逃し防止）
- コメント内の「🔴 修正必須」テキストマッチだけに頼らない

### マージ待ちPRの自動処理
- 修正対象PRが0件の場合、`reviewDecision: APPROVED` のマージ待ちPRを探して積極的にマージ
- mainへの取り込みが滞らないようにする