### PR TITLE
fix: レビュー送信をgh pr reviewに統一し、fix-reviewの検出を3層化

### DIFF
--- a/.kiro/prompts/fix-review-issues.md
+++ b/.kiro/prompts/fix-review-issues.md
@@ -5,23 +5,32 @@
 
 ## 1サイクルの処理
 
-### Step 1: 修正が必要なPRを検出
+### Step 1: 修正が必要なPRを検出（多層検出）
 
-まず `reviewDecision` で CHANGES_REQUESTED のPRを検出する:
+以下の3層で検出し、いずれか1つでも該当すれば修正対象とする。
+
+#### 層1: reviewDecision（最も信頼性が高い）
 ```bash
 gh pr list --json number,title,headRefName,reviewDecision --limit 20
 ```
 `reviewDecision` が `CHANGES_REQUESTED` のPRを対象にする。
 
-次に、対象PRのレビューコメントとPRコメントの両方から指摘内容を取得する:
+#### 層2: 最新レビューのstate
+`reviewDecision` が空や `REVIEW_REQUIRED` の場合でも、個別レビューに REQUEST_CHANGES がある場合がある:
+```bash
+gh pr view <number> --json reviews --jq '.reviews[-1].state'
+```
+最新レビューの state が `CHANGES_REQUESTED` なら対象。
+
+#### 層3: コメント・レビュー本文のテキストマッチ
 ```bash
 gh pr view <number> --json reviews,comments
 ```
-「🔴 修正必須」または「🔴 マージ失敗」を含むレビュー/コメントから指摘を抽出する。
+「🔴 修正必須」または「🔴 マージ失敗」を含むレビュー/コメントがあれば対象。
 
-**重要**: `reviewDecision` が `CHANGES_REQUESTED` であれば、コメント内に「🔴 修正必須」の文字列がなくても修正対象とする。レビュー本文（reviews）にも指摘が含まれている場合があるため、comments だけでなく reviews も必ず確認すること。
+**重要**: 3層のいずれかで検出されれば修正対象とする。reviews と comments の両方を必ず確認すること。
 
-対象がなければ「監視継続中。」で終了（次サイクルで再チェック）。
+対象がなければ、APPROVEDでマージ待ちのPRを処理（後述）して終了。
 
 ### Step 2: 指摘内容の取得と理解
 

--- a/.kiro/prompts/review.md
+++ b/.kiro/prompts/review.md
@@ -118,6 +118,15 @@ steering ファイル（`.kiro/steering/`）を読み、プロジェクト固有
 | 指摘が1つでもある | **🔴 修正必須** |
 | 指摘ゼロ（全チェック通過の証拠あり） | **🟢 LGTM** |
 
+## レビュー結果の送信（必須ルール）
+
+レビュー結果は**必ず `gh pr review` コマンドで送信する**。`gh pr comment` でレビュー結果を書くのは禁止。
+
+- 🔴 修正必須 → `gh pr review <number> --request-changes --body "<レビュー本文>"`
+- 🟢 LGTM → `gh pr review <number> --approve --body "<レビュー本文>"`
+
+これにより GitHub の `reviewDecision` が正しく設定され、他のエージェントが状態を検出できる。
+
 ## 出力フォーマット
 
 先頭行に判定を書く。
@@ -177,6 +186,7 @@ gh pr comment <number> --body "🔴 マージ失敗: コンフリクトが発生
 - 呼び出し元を追跡せずに「影響なし」と判断 → **禁止**
 - 検証実施記録なしで APPROVE → **禁止**
 - 「良い点」から始めて甘い空気を作る → **禁止**（指摘事項から始める）
+- `gh pr comment` でレビュー結果を書く → **禁止**（必ず `gh pr review` を使う）
 
 ## Dependabot PR処理
 


### PR DESCRIPTION
## 変更内容

### review.md
- レビュー結果は必ず `gh pr review` で送信するルールを追加
- `gh pr comment` でのレビュー結果送信を禁止事項に追加
- これにより `reviewDecision` が確実に設定される

### fix-review-issues.md
- PR検出を3層化:
  1. `reviewDecision: CHANGES_REQUESTED`（最も信頼性が高い）
  2. 最新レビューの `state`（reviewDecisionが空の場合のフォールバック）
  3. コメント/レビュー本文の「🔴」テキストマッチ（最終フォールバック）
- いずれか1つでも該当すれば修正対象とする