### PR TITLE
fix: サーバー起動をjust devに統一、INCEPTIONで生成させる

### DIFF
--- a/.kiro/prompts/e2e-bug-hunt.md
+++ b/.kiro/prompts/e2e-bug-hunt.md
@@ -19,6 +19,7 @@
 2. 既存E2Eテストを読む（e2e/）→ テストパターン・ヘルパーを把握
 3. Playwright設定を読む（playwright.config.ts）→ baseURL, webServer, timeout確認
 4. 既存issueを取得 → 重複防止
+5. サーバーを起動: `just dev`（直接 `uvicorn` や `npm run dev` を実行してはならない）
 
 ## 巡回シナリオ（サイクルごとにローテーション）
 

--- a/.kiro/prompts/watch-main.md
+++ b/.kiro/prompts/watch-main.md
@@ -35,14 +35,16 @@
 
 ## サーバー起動方法（必須）
 
-サーバーを起動する際は、必ず以下のスクリプトを使用する。直接 `uvicorn` や `npm run dev` を実行してはならない（ターミナルがブロックされるため）。
+サーバーを起動する際は、必ず以下のいずれかを使用する。直接 `uvicorn` や `npm run dev` を実行してはならない（ターミナルがブロックされるため）。
 
 ```bash
-./scripts/start-server.sh
+just dev                    # 推奨
+./scripts/start-server.sh  # just dev のラッパー
 ```
 
-このスクリプトは:
-- 既存のサーバープロセスを停止
-- バックエンド・フロントエンドを `nohup` でバックグラウンド起動
-- サーバーが ready になるまで待機してから終了
-- ログは `/tmp/dev-backend.log`, `/tmp/dev-frontend.log` に出力
+停止する場合:
+```bash
+just dev-stop
+```
+
+`just dev` のレシピはINCEPTIONフェーズで生成される。justfileに `dev` レシピがない場合はエラーになる。

--- a/.kiro/skills/inception/references/architecture-design.md
+++ b/.kiro/skills/inception/references/architecture-design.md
@@ -37,3 +37,41 @@
 - `architecture.md`
 - `technology-stack.md`
 - `directory-structure.md`
+
+### 5. justfile にサーバー起動コマンドを追加（必須）
+
+アーキテクチャ確定後、`justfile` に以下のレシピを追加する。これは後続の全エージェント（Watch-Main, E2E-Hunt等）がサーバー起動に使用する。
+
+追加するレシピ:
+
+```just
+# Start all dev servers in background
+dev:
+    #!/usr/bin/env bash
+    # 既存プロセスを停止
+    lsof -ti:{バックエンドポート} 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+    lsof -ti:{フロントエンドポート} 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+    sleep 1
+    # バックエンド起動
+    cd {バックエンドディレクトリ} && nohup {バックエンド起動コマンド} > /tmp/dev-backend.log 2>&1 &
+    # フロントエンド起動
+    cd {フロントエンドディレクトリ} && nohup {フロントエンド起動コマンド} > /tmp/dev-frontend.log 2>&1 &
+    # ready待機
+    for i in $(seq 1 30); do
+      if lsof -ti:{バックエンドポート} > /dev/null 2>&1 && lsof -ti:{フロントエンドポート} > /dev/null 2>&1; then
+        echo "✅ All servers ready"; exit 0
+      fi
+      sleep 2
+    done
+    echo "⚠️ Timeout"; exit 1
+
+# Stop all dev servers
+dev-stop:
+    lsof -ti:{バックエンドポート} 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+    lsof -ti:{フロントエンドポート} 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+    @echo "✅ Servers stopped"
+```
+
+`{バックエンドポート}`, `{フロントエンドポート}`, `{起動コマンド}` はアーキテクチャで決定した内容に置き換える。
+
+**重要**: `just dev` が正常に動作することを実際に実行して確認すること。動かない場合はその場で修正する。

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -1,59 +1,18 @@
 #!/usr/bin/env bash
 # Usage: ./scripts/start-server.sh
-# Starts dev servers in background, waits for them to be ready, then exits.
-# Kiro's shell tool can run this without blocking.
+# Wrapper that calls `just dev` to start all dev servers in background.
+# The actual startup commands are defined in justfile (generated during INCEPTION).
 
 set -euo pipefail
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-
-# Kill existing dev servers
-kill_servers() {
-  for port in 8000 5173 3000 3001; do
-    lsof -ti:"$port" 2>/dev/null | xargs -r kill -9 2>/dev/null || true
-  done
-}
-
-kill_servers
-sleep 1
-
-# Detect and start backend
-if [[ -f "$PROJECT_ROOT/backend/pyproject.toml" ]]; then
-  cd "$PROJECT_ROOT/backend"
-  nohup uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 > /tmp/dev-backend.log 2>&1 &
-  echo "Backend PID: $!"
-elif [[ -f "$PROJECT_ROOT/server/package.json" ]]; then
-  cd "$PROJECT_ROOT/server"
-  nohup npm run dev > /tmp/dev-backend.log 2>&1 &
-  echo "Backend PID: $!"
+if ! command -v just &> /dev/null; then
+  echo "❌ just is not installed. Run: brew install just"
+  exit 1
 fi
 
-# Detect and start frontend
-if [[ -f "$PROJECT_ROOT/frontend/package.json" ]]; then
-  cd "$PROJECT_ROOT/frontend"
-  if grep -q '"dev"' package.json; then
-    nohup npm run dev > /tmp/dev-frontend.log 2>&1 &
-    echo "Frontend PID: $!"
-  fi
+if ! grep -q '^dev:' justfile 2>/dev/null; then
+  echo "❌ 'dev' recipe not found in justfile. Run INCEPTION first to generate it."
+  exit 1
 fi
 
-# Wait for servers to be ready
-echo "Waiting for servers..."
-for i in $(seq 1 30); do
-  READY=true
-  for port in 8000 5173; do
-    if lsof -ti:"$port" > /dev/null 2>&1; then
-      :
-    else
-      READY=false
-    fi
-  done
-  if $READY; then
-    echo "✅ All servers ready"
-    exit 0
-  fi
-  sleep 2
-done
-
-echo "⚠️ Timeout waiting for servers. Check /tmp/dev-backend.log and /tmp/dev-frontend.log"
-exit 1
+just dev


### PR DESCRIPTION
## 変更内容

### INCEPTIONで起動コマンドを確定
- architecture-design.md のStep 5で `justfile` に `dev` / `dev-stop` レシピを生成
- 実際のプロジェクトに合わせたポート・コマンドを設定
- 動作確認を必須化

### エージェント側
- `start-server.sh`: `just dev` を呼ぶだけのラッパーに簡素化
- `watch-main.md`, `e2e-bug-hunt.md`: `just dev` の使用を明記、直接起動を禁止