### PR TITLE
fix: gitコマンドでエディタを起動しないルールを追加

### DIFF
--- a/.kiro/prompts/resolve-conflicts.md
+++ b/.kiro/prompts/resolve-conflicts.md
@@ -49,3 +49,5 @@ git checkout main
 - `--force` ではなく `--force-with-lease` を使う
 - コンフリクトマーカーを残したままコミットしない
 - 理解せずに片方を丸ごと採用しない
+- **vim/nano等のエディタを起動しない** — `git rebase --continue` でエディタが開く場合は `GIT_EDITOR=true git rebase --continue` または `git -c core.editor=true rebase --continue` を使う
+- コンフリクト解決はファイルの読み書きツールで行い、エディタコマンドは使わない

--- a/.kiro/steering/development-rules.md
+++ b/.kiro/steering/development-rules.md
@@ -71,6 +71,7 @@ description: 全タスクに適用されるコアルール
 - コミット: Conventional Commits、英語、アトミック
 - PR: 英語タイトル + 本文、`Closes #N`、squash mergeのみ
 - CI通過前のマージ禁止。force merge禁止。
+- **vim/nano等のエディタを起動するコマンドは禁止** — `git rebase`, `git commit` 等でエディタが開くとエージェントがハングする。必ず `--no-edit`, `-m` オプション等でエディタ起動を回避すること。`GIT_EDITOR=true` を設定するか、コマンドにメッセージを直接渡す。
 
 ### pre-commit（必須）
 


### PR DESCRIPTION
エージェントがgit rebase --continue等でvimが起動するとハングする問題を防止。steeringとresolve-conflicts.mdにエディタ起動禁止ルールを追加。