### PR TITLE
feat: add real-time agent dashboard to Status tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 aidlc-docs/
 issue/task.md
+.agent-status/

--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -12,6 +12,17 @@ PROMPT_NAME="${1:?Usage: agent.sh <prompt-name>}"
 PROMPT_FILE=".kiro/prompts/${PROMPT_NAME}.md"
 INTERVAL="${AGENT_INTERVAL:-120}"
 MAX_ERRORS=5
+STATUS_DIR=".agent-status"
+STATUS_FILE="${STATUS_DIR}/${AGENT_ID:-$PROMPT_NAME}.json"
+
+mkdir -p "$STATUS_DIR"
+
+update_status() {
+  local state="$1" detail="${2:-}"
+  cat > "$STATUS_FILE" <<JSON
+{"agent":"${AGENT_ID:-$PROMPT_NAME}","prompt":"$PROMPT_NAME","state":"$state","detail":"$detail","cycle":$cycle,"errors":$error_count,"ts":"$(date '+%H:%M:%S')"}
+JSON
+}
 
 if [[ ! -f "$PROMPT_FILE" ]]; then
   echo "❌ Prompt not found: $PROMPT_FILE"
@@ -80,7 +91,9 @@ echo "   Interval: ${INTERVAL}s"
 echo ""
 
 # Phase 1: Wait for work
+update_status "⏳ waiting" ""
 wait_for_work
+update_status "🟢 ready" ""
 echo "✅ Work detected. Starting agent loop."
 echo ""
 
@@ -88,21 +101,23 @@ echo ""
 while true; do
   cycle=$((cycle + 1))
   echo "━━━ Cycle #${cycle} [$(date '+%H:%M:%S')] ━━━"
+  update_status "🔄 running" "cycle #${cycle}"
 
   if kiro-cli chat \
     --no-interactive \
     --trust-all-tools \
     "$(cat "$PROMPT_FILE")" 2>&1; then
     error_count=0
+    update_status "✅ done" "cycle #${cycle}"
     echo "✅ Cycle #${cycle} complete"
   else
     error_count=$((error_count + 1))
+    update_status "⚠️ error" "cycle #${cycle} (${error_count}/${MAX_ERRORS})"
     echo "⚠️  Cycle #${cycle} failed (${error_count}/${MAX_ERRORS})"
-    [[ $error_count -ge $MAX_ERRORS ]] && echo "❌ Too many errors. Stopping." && exit 1
+    [[ $error_count -ge $MAX_ERRORS ]] && update_status "💀 dead" "too many errors" && echo "❌ Too many errors. Stopping." && exit 1
   fi
 
-  # Single-run agents (none currently)
-
+  update_status "😴 sleeping" "next in ${INTERVAL}s"
   echo "⏳ Next cycle in ${INTERVAL}s..."
   sleep "$INTERVAL"
 done

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Real-time agent dashboard for zellij Status tab
+set -euo pipefail
+
+STATUS_DIR=".agent-status"
+REFRESH=3
+
+# Agent display config: id → emoji + role
+declare -A ICONS=(
+  [Dev-Server]="🖥️  Dev-Server"
+  [Impl-1]="🔨 Impl-1"
+  [Impl-2]="🔨 Impl-2"
+  [Review-1]="🔍 Review-1"
+  [Review-2]="🔍 Review-2"
+  [Fix-Review-1]="🔧 Fix-Review-1"
+  [Fix-Review-2]="🔧 Fix-Review-2"
+  [Watch-Main]="👀 Watch-Main"
+  [E2E-Hunt]="🧪 E2E-Hunt"
+  [Improve]="💡 Improve"
+)
+
+ORDER=(Dev-Server Impl-1 Impl-2 Review-1 Review-2 Fix-Review-1 Fix-Review-2 Watch-Main E2E-Hunt Improve)
+
+# Colors
+R='\033[0m'
+DIM='\033[2m'
+BOLD='\033[1m'
+CYAN='\033[36m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+MAGENTA='\033[35m'
+BLUE='\033[34m'
+WHITE='\033[97m'
+BG_DARK='\033[48;5;236m'
+
+state_color() {
+  case "$1" in
+    *running*)  echo -e "${CYAN}" ;;
+    *done*)     echo -e "${GREEN}" ;;
+    *error*)    echo -e "${RED}" ;;
+    *dead*)     echo -e "${RED}${BOLD}" ;;
+    *waiting*)  echo -e "${YELLOW}" ;;
+    *ready*)    echo -e "${GREEN}" ;;
+    *sleeping*) echo -e "${MAGENTA}" ;;
+    *)          echo -e "${DIM}" ;;
+  esac
+}
+
+progress_bar() {
+  local state="$1" width=20
+  local filled empty char
+  case "$state" in
+    *running*)  filled=20; char="▓" ;;
+    *done*)     filled=20; char="█" ;;
+    *error*)    filled=20; char="░" ;;
+    *dead*)     filled=20; char="✕" ;;
+    *waiting*)  filled=$(( (SECONDS / 2) % (width + 1) )); char="▒" ;;
+    *ready*)    filled=20; char="█" ;;
+    *sleeping*) filled=$(( (SECONDS / 2) % (width + 1) )); char="·" ;;
+    *)          filled=0;  char="·" ;;
+  esac
+  empty=$((width - filled))
+  printf '%s' "$(printf "%${filled}s" | tr ' ' "$char")$(printf "%${empty}s" | tr ' ' '·')"
+}
+
+while true; do
+  clear
+
+  # Header
+  echo -e "${BOLD}${CYAN}"
+  echo "  ╔══════════════════════════════════════════════════════════════╗"
+  echo "  ║           🤖  K I R O   P I P E L I N E   🤖              ║"
+  echo "  ╚══════════════════════════════════════════════════════════════╝${R}"
+  echo ""
+
+  # Stats summary
+  local_time=$(date '+%H:%M:%S')
+  total=0; running=0; errors=0; sleeping=0
+  for id in "${ORDER[@]}"; do
+    f="${STATUS_DIR}/${id}.json"
+    [[ -f "$f" ]] || continue
+    total=$((total + 1))
+    state=$(jq -r '.state // ""' "$f" 2>/dev/null || true)
+    case "$state" in
+      *running*) running=$((running + 1)) ;;
+      *error*|*dead*) errors=$((errors + 1)) ;;
+      *sleeping*) sleeping=$((sleeping + 1)) ;;
+    esac
+  done
+  echo -e "  ${DIM}${local_time}${R}  ${WHITE}Agents: ${total}${R}  ${CYAN}▶ ${running}${R}  ${RED}✕ ${errors}${R}  ${MAGENTA}◆ ${sleeping}${R}"
+  echo ""
+
+  # Agent rows
+  echo -e "  ${DIM}┌──────────────────┬──────────────┬──────────────────────┬────────┐${R}"
+  printf "  ${DIM}│${R} ${BOLD}%-16s${R} ${DIM}│${R} ${BOLD}%-12s${R} ${DIM}│${R} ${BOLD}%-20s${R} ${DIM}│${R} ${BOLD}%-6s${R} ${DIM}│${R}\n" "Agent" "State" "Progress" "Cycle"
+  echo -e "  ${DIM}├──────────────────┼──────────────┼──────────────────────┼────────┤${R}"
+
+  for id in "${ORDER[@]}"; do
+    f="${STATUS_DIR}/${id}.json"
+    icon="${ICONS[$id]:-$id}"
+
+    if [[ ! -f "$f" ]]; then
+      printf "  ${DIM}│${R} %-17s ${DIM}│${R} ${DIM}%-16s${R} ${DIM}│${R} ${DIM}%-20s${R} ${DIM}│${R} ${DIM}%-6s${R} ${DIM}│${R}\n" \
+        "$icon" "  ○ offline" "····················" "  -"
+      continue
+    fi
+
+    state=$(jq -r '.state // "?"' "$f" 2>/dev/null || echo "?")
+    detail=$(jq -r '.detail // ""' "$f" 2>/dev/null || echo "")
+    cycle=$(jq -r '.cycle // 0' "$f" 2>/dev/null || echo "0")
+    ts=$(jq -r '.ts // ""' "$f" 2>/dev/null || echo "")
+
+    sc=$(state_color "$state")
+    bar=$(progress_bar "$state")
+
+    # Truncate detail
+    [[ ${#detail} -gt 12 ]] && detail="${detail:0:11}…"
+
+    printf "  ${DIM}│${R} %-17s ${DIM}│${R} ${sc}%-14s${R} ${DIM}│${R} ${sc}%-20s${R} ${DIM}│${R} %6s ${DIM}│${R}\n" \
+      "$icon" "  $state" "$bar" "#${cycle}"
+  done
+
+  echo -e "  ${DIM}└──────────────────┴──────────────┴──────────────────────┴────────┘${R}"
+  echo ""
+
+  # Detail section
+  echo -e "  ${BOLD}📋 Details${R}"
+  echo -e "  ${DIM}─────────────────────────────────────────────────────────────────${R}"
+  for id in "${ORDER[@]}"; do
+    f="${STATUS_DIR}/${id}.json"
+    [[ -f "$f" ]] || continue
+    state=$(jq -r '.state // ""' "$f" 2>/dev/null || true)
+    detail=$(jq -r '.detail // ""' "$f" 2>/dev/null || true)
+    ts=$(jq -r '.ts // ""' "$f" 2>/dev/null || true)
+    [[ -z "$detail" && "$state" != *running* ]] && continue
+    sc=$(state_color "$state")
+    echo -e "  ${sc}${ICONS[$id]:-$id}${R} ${DIM}${ts}${R} ${detail}"
+  done
+
+  echo ""
+  echo -e "  ${DIM}Refresh: ${REFRESH}s │ Ctrl+C to exit${R}"
+
+  sleep "$REFRESH"
+done

--- a/scripts/pipeline.kdl
+++ b/scripts/pipeline.kdl
@@ -21,43 +21,43 @@ layout {
         pane split_direction="horizontal" {
             pane split_direction="vertical" {
                 pane command="bash" name="Dev-Server" {
-                    args "-c" "./scripts/agent.sh dev-server"
+                    args "-c" "AGENT_ID=Dev-Server ./scripts/agent.sh dev-server"
                 }
                 pane command="bash" name="Impl-1" {
-                    args "-c" "AGENT_INTERVAL=10 ./scripts/agent.sh implement"
+                    args "-c" "AGENT_ID=Impl-1 AGENT_INTERVAL=10 ./scripts/agent.sh implement"
                 }
                 pane command="bash" name="Impl-2" {
-                    args "-c" "AGENT_INTERVAL=10 ./scripts/agent.sh implement"
+                    args "-c" "AGENT_ID=Impl-2 AGENT_INTERVAL=10 ./scripts/agent.sh implement"
                 }
                 pane command="bash" name="Review-1" {
-                    args "-c" "AGENT_INTERVAL=10 ./scripts/agent.sh review"
+                    args "-c" "AGENT_ID=Review-1 AGENT_INTERVAL=10 ./scripts/agent.sh review"
                 }
                 pane command="bash" name="Review-2" {
-                    args "-c" "AGENT_INTERVAL=10 ./scripts/agent.sh review"
+                    args "-c" "AGENT_ID=Review-2 AGENT_INTERVAL=10 ./scripts/agent.sh review"
                 }
             }
             pane split_direction="vertical" {
                 pane command="bash" name="Fix-Review-1" {
-                    args "-c" "AGENT_INTERVAL=10 ./scripts/agent.sh fix-review"
+                    args "-c" "AGENT_ID=Fix-Review-1 AGENT_INTERVAL=10 ./scripts/agent.sh fix-review"
                 }
                 pane command="bash" name="Fix-Review-2" {
-                    args "-c" "AGENT_INTERVAL=10 ./scripts/agent.sh fix-review"
+                    args "-c" "AGENT_ID=Fix-Review-2 AGENT_INTERVAL=10 ./scripts/agent.sh fix-review"
                 }
                 pane command="bash" name="Watch-Main" {
-                    args "-c" "./scripts/agent.sh watch-main"
+                    args "-c" "AGENT_ID=Watch-Main ./scripts/agent.sh watch-main"
                 }
                 pane command="bash" name="E2E-Hunt" {
-                    args "-c" "./scripts/agent.sh e2e-bug-hunt"
+                    args "-c" "AGENT_ID=E2E-Hunt ./scripts/agent.sh e2e-bug-hunt"
                 }
                 pane command="bash" name="Improve" {
-                    args "-c" "echo '── Keybinds ──'; echo 'Ctrl+h/j/k/l  Move pane'; echo 'Alt+1/2       Switch tab'; echo 'Ctrl+q        Quit zellij'; echo '──────────────'; echo ''; AGENT_INTERVAL=600 ./scripts/agent.sh improve"
+                    args "-c" "AGENT_ID=Improve AGENT_INTERVAL=600 ./scripts/agent.sh improve"
                 }
             }
         }
     }
     tab name="Status" {
-        pane command="bash" name="task.md" {
-            args "-c" "while true; do clear; cat issue/task.md 2>/dev/null || echo 'No task.md yet'; sleep 5; done"
+        pane command="bash" name="Dashboard" {
+            args "-c" "./scripts/dashboard.sh"
         }
     }
 }


### PR DESCRIPTION
zellijのStatusタブにリアルタイムダッシュボードを追加。

## Changes
- `agent.sh`: 各フェーズでJSON status を `.agent-status/` に書き出し
- `dashboard.sh`: 絵文字・色分け・プログレスバー付きテーブル表示（3秒リフレッシュ）
- `pipeline.kdl`: 全paneに `AGENT_ID` 追加、StatusタブをDashboardに差し替え
- `.gitignore`: `.agent-status/` を追加