### PR TITLE
feat: add orchestrator for dynamic agent role allocation

### DIFF
--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -11,6 +11,7 @@ export EDITOR=true
 PROMPT_NAME="${1:?Usage: agent.sh <prompt-name>}"
 PROMPT_FILE=".kiro/prompts/${PROMPT_NAME}.md"
 INTERVAL="${AGENT_INTERVAL:-120}"
+ONCE="${AGENT_ONCE:-false}"
 MAX_ERRORS=5
 STATUS_DIR=".agent-status"
 STATUS_FILE="${STATUS_DIR}/${AGENT_ID:-$PROMPT_NAME}.json"
@@ -115,6 +116,13 @@ while true; do
     update_status "⚠️ error" "cycle #${cycle} (${error_count}/${MAX_ERRORS})"
     echo "⚠️  Cycle #${cycle} failed (${error_count}/${MAX_ERRORS})"
     [[ $error_count -ge $MAX_ERRORS ]] && update_status "💀 dead" "too many errors" && echo "❌ Too many errors. Stopping." && exit 1
+  fi
+
+  # Once mode: exit after single cycle (for orchestrator)
+  if [[ "$ONCE" == "true" ]]; then
+    update_status "⏹️ finished" "cycle #${cycle}"
+    echo "🏁 Once mode — exiting."
+    exit 0
   fi
 
   update_status "😴 sleeping" "next in ${INTERVAL}s"

--- a/scripts/orchestrator.sh
+++ b/scripts/orchestrator.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Orchestrator: dynamically assigns roles to 10 zellij panes
+# based on current issue/PR state.
+set -euo pipefail
+
+export GIT_EDITOR=true
+export EDITOR=true
+
+POLL_INTERVAL="${ORCH_INTERVAL:-30}"
+PANE_COUNT=10
+PROJECT_CWD="$(pwd)"
+STATUS_DIR=".agent-status"
+mkdir -p "$STATUS_DIR"
+
+# ── Helpers ──
+
+count_issues() {
+  gh issue list --state open --json number,assignees \
+    --jq "[.[] | select(.assignees | length == 0)] | length" 2>/dev/null || echo "0"
+}
+
+count_prs_needing_review() {
+  gh pr list --json number,reviewDecision,reviews \
+    --jq '[.[] | select(.reviewDecision == "" or .reviewDecision == "REVIEW_REQUIRED")] | length' 2>/dev/null || echo "0"
+}
+
+count_prs_changes_requested() {
+  gh pr list --json number,reviewDecision \
+    --jq '[.[] | select(.reviewDecision == "CHANGES_REQUESTED")] | length' 2>/dev/null || echo "0"
+}
+
+count_prs_approved() {
+  gh pr list --json number,reviewDecision \
+    --jq '[.[] | select(.reviewDecision == "APPROVED")] | length' 2>/dev/null || echo "0"
+}
+
+has_merged_prs() {
+  local c
+  c=$(gh pr list --state merged --limit 1 --json number --jq 'length' 2>/dev/null || echo "0")
+  [[ "$c" -gt 0 ]]
+}
+
+# ── Role allocation ──
+# Returns a newline-separated list of 10 roles
+allocate_roles() {
+  local issues="$1" need_review="$2" changes_req="$3" approved="$4" has_merges="$5"
+  local roles=()
+
+  # Slot 0: always dev-server
+  roles+=(dev-server)
+
+  # Remaining 9 slots to fill
+  local remaining=9
+  local impl=0 review=0 fix=0 watch=0 e2e=0 improve=0
+
+  # 1) Fix-review: 1 per 2 CHANGES_REQUESTED PRs (min 0, max 2)
+  if [[ "$changes_req" -gt 0 ]]; then
+    fix=$(( (changes_req + 1) / 2 ))
+    [[ $fix -gt 2 ]] && fix=2
+  fi
+
+  # 2) Review: 1 per 2 PRs needing review + 1 per 3 approved (for merge duty), min 1 if any PRs, max 3
+  if [[ "$need_review" -gt 0 || "$approved" -gt 0 ]]; then
+    review=$(( (need_review + 1) / 2 + (approved + 2) / 3 ))
+    [[ $review -lt 1 ]] && review=1
+    [[ $review -gt 3 ]] && review=3
+  fi
+
+  # 3) Watch-main + E2E: 1 each if merges exist
+  if $has_merges; then
+    watch=1
+    e2e=1
+  fi
+
+  # 4) Improve: 1 if merges exist and we have spare slots
+  if $has_merges; then
+    improve=1
+  fi
+
+  # 5) Impl: fill the rest (at least 1 if issues > 0)
+  local used=$((fix + review + watch + e2e + improve))
+  impl=$((remaining - used))
+  [[ $impl -lt 0 ]] && impl=0
+
+  # If no issues, redistribute impl slots to review
+  if [[ "$issues" -eq 0 && "$impl" -gt 0 ]]; then
+    review=$((review + impl))
+    impl=0
+  fi
+
+  # If nothing to do at all, keep slots idle
+  local total=$((impl + review + fix + watch + e2e + improve))
+  local idle=$((remaining - total))
+
+  # Build role list
+  for ((i=0; i<impl; i++));    do roles+=(implement); done
+  for ((i=0; i<review; i++));  do roles+=(review); done
+  for ((i=0; i<fix; i++));     do roles+=(fix-review); done
+  [[ $watch -gt 0 ]]   && roles+=(watch-main)
+  [[ $e2e -gt 0 ]]     && roles+=(e2e-bug-hunt)
+  [[ $improve -gt 0 ]] && roles+=(improve)
+  for ((i=0; i<idle; i++));    do roles+=(idle); done
+
+  printf '%s\n' "${roles[@]}"
+}
+
+# ── Pane management ──
+
+declare -A PANE_ROLE   # pane_index -> current role
+declare -A PANE_PID    # pane_index -> background PID
+
+for ((i=0; i<PANE_COUNT; i++)); do
+  PANE_ROLE[$i]=""
+  PANE_PID[$i]=""
+done
+
+dispatch_pane() {
+  local idx="$1" role="$2"
+  local agent_id
+
+  # Name mapping
+  case "$role" in
+    dev-server)   agent_id="Dev-Server" ;;
+    implement)    agent_id="Impl-${idx}" ;;
+    review)       agent_id="Review-${idx}" ;;
+    fix-review)   agent_id="Fix-Review-${idx}" ;;
+    watch-main)   agent_id="Watch-Main" ;;
+    e2e-bug-hunt) agent_id="E2E-Hunt" ;;
+    improve)      agent_id="Improve" ;;
+    idle)         agent_id="Idle-${idx}" ;;
+  esac
+
+  if [[ "$role" == "idle" ]]; then
+    cat > "${STATUS_DIR}/${agent_id}.json" <<JSON
+{"agent":"${agent_id}","prompt":"idle","state":"💤 idle","detail":"waiting for work","cycle":0,"errors":0,"ts":"$(date '+%H:%M:%S')"}
+JSON
+    PANE_ROLE[$idx]="$role"
+    return
+  fi
+
+  # Launch via zellij run into the pane
+  zellij run \
+    --name "$agent_id" \
+    --cwd "$PROJECT_CWD" \
+    --close-on-exit \
+    -- bash -c "AGENT_ID=${agent_id} AGENT_ONCE=true AGENT_INTERVAL=10 ./scripts/agent.sh ${role}" &
+
+  PANE_PID[$idx]=$!
+  PANE_ROLE[$idx]="$role"
+}
+
+# ── Main loop ──
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  🎭 Orchestrator started"
+echo "  📊 Polling every ${POLL_INTERVAL}s"
+echo "  🖥️  Managing ${PANE_COUNT} panes"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+cycle=0
+while true; do
+  cycle=$((cycle + 1))
+
+  # Gather state
+  issues=$(count_issues)
+  need_review=$(count_prs_needing_review)
+  changes_req=$(count_prs_changes_requested)
+  approved=$(count_prs_approved)
+  has_merges=false
+  has_merged_prs && has_merges=true
+
+  echo "━━━ Orchestrator cycle #${cycle} [$(date '+%H:%M:%S')] ━━━"
+  echo "  📋 Unassigned issues: ${issues}"
+  echo "  🔍 PRs needing review: ${need_review}"
+  echo "  🔧 PRs changes requested: ${changes_req}"
+  echo "  ✅ PRs approved (merge): ${approved}"
+  echo ""
+
+  # Allocate roles
+  mapfile -t new_roles < <(allocate_roles "$issues" "$need_review" "$changes_req" "$approved" "$has_merges")
+
+  # Show allocation
+  echo "  🎭 Allocation:"
+  for ((i=0; i<PANE_COUNT; i++)); do
+    role="${new_roles[$i]:-idle}"
+    prev="${PANE_ROLE[$i]:-}"
+    changed=""
+    [[ "$role" != "$prev" ]] && changed=" ← was ${prev:-none}"
+    echo "    Pane ${i}: ${role}${changed}"
+  done
+  echo ""
+
+  # Check which panes are free (finished or idle)
+  for ((i=0; i<PANE_COUNT; i++)); do
+    role="${new_roles[$i]:-idle}"
+    prev="${PANE_ROLE[$i]:-}"
+    pid="${PANE_PID[$i]:-}"
+
+    # If pane has a running process, skip
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      continue
+    fi
+
+    # Pane is free — dispatch new role
+    dispatch_pane "$i" "$role"
+  done
+
+  echo "  ⏳ Next check in ${POLL_INTERVAL}s..."
+  echo ""
+  sleep "$POLL_INTERVAL"
+done

--- a/scripts/pipeline.kdl
+++ b/scripts/pipeline.kdl
@@ -20,37 +20,8 @@ layout {
     tab name="Pipeline" {
         pane split_direction="horizontal" {
             pane split_direction="vertical" {
-                pane command="bash" name="Dev-Server" {
-                    args "-c" "AGENT_ID=Dev-Server ./scripts/agent.sh dev-server"
-                }
-                pane command="bash" name="Impl-1" {
-                    args "-c" "AGENT_ID=Impl-1 AGENT_INTERVAL=10 ./scripts/agent.sh implement"
-                }
-                pane command="bash" name="Impl-2" {
-                    args "-c" "AGENT_ID=Impl-2 AGENT_INTERVAL=10 ./scripts/agent.sh implement"
-                }
-                pane command="bash" name="Review-1" {
-                    args "-c" "AGENT_ID=Review-1 AGENT_INTERVAL=10 ./scripts/agent.sh review"
-                }
-                pane command="bash" name="Review-2" {
-                    args "-c" "AGENT_ID=Review-2 AGENT_INTERVAL=10 ./scripts/agent.sh review"
-                }
-            }
-            pane split_direction="vertical" {
-                pane command="bash" name="Fix-Review-1" {
-                    args "-c" "AGENT_ID=Fix-Review-1 AGENT_INTERVAL=10 ./scripts/agent.sh fix-review"
-                }
-                pane command="bash" name="Fix-Review-2" {
-                    args "-c" "AGENT_ID=Fix-Review-2 AGENT_INTERVAL=10 ./scripts/agent.sh fix-review"
-                }
-                pane command="bash" name="Watch-Main" {
-                    args "-c" "AGENT_ID=Watch-Main ./scripts/agent.sh watch-main"
-                }
-                pane command="bash" name="E2E-Hunt" {
-                    args "-c" "AGENT_ID=E2E-Hunt ./scripts/agent.sh e2e-bug-hunt"
-                }
-                pane command="bash" name="Improve" {
-                    args "-c" "AGENT_ID=Improve AGENT_INTERVAL=600 ./scripts/agent.sh improve"
+                pane command="bash" name="Orchestrator" {
+                    args "-c" "./scripts/orchestrator.sh"
                 }
             }
         }


### PR DESCRIPTION
10pane固定でエージェントの役割を動的に割り当てるオーケストレーターを追加。

## 仕組み
- `orchestrator.sh` が30秒ごとにissue/PR数をポーリング
- 状況に応じて10paneの役割を動的に決定:
  - issue多い → Impl多め
  - PR溜まってる → Review多め  
  - CHANGES_REQUESTED → Fix-Review追加
  - マージ済みあり → Watch-Main, E2E, Improve追加
  - 仕事なし → idle
- `zellij run` で各paneにエージェントを起動
- `AGENT_ONCE=true` で1サイクル完了後に終了 → 次サイクルで再割り当て

## 割り当てロジック例
| 状況 | Impl | Review | Fix | Watch | E2E | Improve | Idle |
|------|------|--------|-----|-------|-----|---------|------|
| issue 10, PR 0 | 8 | 0 | 0 | 0 | 0 | 0 | 1 |
| issue 5, PR 4 | 4 | 2 | 0 | 1 | 1 | 1 | 0 |
| issue 0, PR 6 | 0 | 6 | 1 | 1 | 1 | 1 | 0 |