### PR TITLE
fix: force no-editor via git config for rebase

### DIFF
--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -7,6 +7,13 @@ set -euo pipefail
 
 export GIT_EDITOR=true
 export EDITOR=true
+export VISUAL=true
+export GIT_SEQUENCE_EDITOR=true
+
+# Force no-editor at git config level (survives subprocesses that reset env)
+git config --global core.editor true
+git config --global sequence.editor true
+git config --global rebase.autosquash true
 
 PROMPT_NAME="${1:?Usage: agent.sh <prompt-name>}"
 PROMPT_FILE=".kiro/prompts/${PROMPT_NAME}.md"


### PR DESCRIPTION
kiro-cliの子プロセスが環境変数を引き継がないケースに対応。

- `git config --global core.editor true`
- `git config --global sequence.editor true`
- `export VISUAL=true` / `GIT_SEQUENCE_EDITOR=true` も追加

これで環境変数・git config・sequence editor の3層でエディタ起動をブロック。