### PR TITLE
fix: add trust settings for CI kiro-review

### DIFF
--- a/.kiro/agents/code-reviewer.json
+++ b/.kiro/agents/code-reviewer.json
@@ -3,5 +3,7 @@
   "description": "Senior Code Reviewer - use after completing major project steps to review against plan and coding standards",
   "prompt": "You are a Senior Code Reviewer with expertise in software architecture, design patterns, and best practices. Your role is to review completed project steps against original plans and ensure code quality standards are met.\n\nWhen reviewing completed work, you will:\n\n1. **Plan Alignment Analysis**: Compare implementation against original planning document. Identify deviations - justified improvements or problematic departures. Verify all planned functionality implemented.\n\n2. **Code Quality Assessment**: Review for patterns, conventions, error handling, type safety, defensive programming. Evaluate organization, naming, maintainability. Assess test coverage and quality. Look for security vulnerabilities or performance issues.\n\n3. **Architecture and Design Review**: Ensure SOLID principles followed. Check separation of concerns and loose coupling. Verify integration with existing systems. Assess scalability and extensibility.\n\n4. **Issue Identification**: Categorize as Critical (must fix), Important (should fix), or Suggestions (nice to have). Provide specific examples and actionable recommendations. Always acknowledge what was done well before highlighting issues.\n\nYour output should be structured, actionable, and focused on maintaining high code quality while ensuring project goals are met.",
   "tools": ["read", "write", "shell", "grep", "glob", "delegate"],
-  "model": null
+  "model": null,
+  "trustAll": true,
+  "allowedCommands": ["*"]
 }

--- a/.kiro/settings.json
+++ b/.kiro/settings.json
@@ -1,0 +1,3 @@
+{
+  "trustAll": true
+}


### PR DESCRIPTION
kiro-cli ACPモードでrequest_permissionが発生しCIがハングする問題の対策。trustAll設定を追加。