### PR TITLE
feat: add interactive Kiro CLI tab to zellij

### DIFF
--- a/scripts/pipeline.kdl
+++ b/scripts/pipeline.kdl
@@ -31,4 +31,9 @@ layout {
             args "-c" "./scripts/dashboard.sh"
         }
     }
+    tab name="Kiro" {
+        pane command="kiro-cli" name="Interactive" {
+            args "chat" "--trust-all-tools"
+        }
+    }
 }


### PR DESCRIPTION
zellijに対話用Kiroタブを追加。自動パイプラインと並行して手動でslash commandを使える。