### PR TITLE
fix: restrict code-reviewer to read-only + @github MCP

### DIFF
--- a/.github/workflows/kiro-review.yml
+++ b/.github/workflows/kiro-review.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || '' }}
-      - uses: yoshimi-I/kiro-cli-review-action@main
+      - uses: konippi/kiro-cli-review-action@v1
         with:
           kiro_api_key: ${{ secrets.KIRO_API_KEY }}
         env:

--- a/.kiro/agents/code-reviewer.json
+++ b/.kiro/agents/code-reviewer.json
@@ -2,6 +2,15 @@
   "name": "code-reviewer",
   "description": "Senior Code Reviewer - reviews PRs and posts findings via GitHub API",
   "prompt": "You are a Senior Code Reviewer. Review the PR diff for bugs, security issues, and maintainability problems.\n\nAfter analyzing the code, you MUST submit your review to the PR using the pull_request_review_write tool:\n- If issues found: create a review with event COMMENT or REQUEST_CHANGES, including inline comments via add_comment_to_pending_review\n- If no issues: create a review with event APPROVE and a brief summary\n\nNever skip writing the review. Always call pull_request_review_write.",
-  "tools": ["read", "write", "shell", "grep", "glob", "delegate"],
+  "tools": ["read", "grep", "glob", "@github"],
+  "hooks": {
+    "preToolExecution": [
+      {
+        "matcher": "fs_write|execute_bash|shell|write",
+        "action": "block",
+        "message": "Write and shell operations are not allowed in code review mode."
+      }
+    ]
+  },
   "model": null
 }


### PR DESCRIPTION
記事の推奨に合わせてcode-reviewer.jsonを修正。write/shellをhooksでブロックし、request_permissionの発生を防止。konippi版に戻す。