### PR TITLE
feat: add session resume support to agent.sh

### DIFF
--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -119,6 +119,7 @@ while true; do
   if kiro-cli chat \
     --no-interactive \
     --trust-all-tools \
+    --resume \
     "$(cat "$PROMPT_FILE")" 2>&1; then
     error_count=0
     update_status "✅ done" "cycle #${cycle}"


### PR DESCRIPTION
Add --resume flag to kiro-cli invocation in agent.sh. Agents resume previous session on restart, enabling stop/restart without context loss.