### PR TITLE
fix: use status file timestamp for alive check

### DIFF
--- a/scripts/orchestrator.sh
+++ b/scripts/orchestrator.sh
@@ -51,9 +51,15 @@ count_alive() {
 
 update_pane_status() {
   local tmp="${PANE_REGISTRY}.tmp"; : > "$tmp"
+  local now; now=$(date +%s)
   while IFS='|' read -r name role pid status; do
     [ -z "$name" ] && continue
-    if kill -0 "$pid" 2>/dev/null; then
+    # Check if status file was updated in the last 120 seconds
+    local mtime=0
+    if [ -f "${STATUS_DIR}/${name}.json" ]; then
+      mtime=$(stat -f%m "${STATUS_DIR}/${name}.json" 2>/dev/null || stat -c%Y "${STATUS_DIR}/${name}.json" 2>/dev/null || echo 0)
+    fi
+    if [ $((now - mtime)) -lt 120 ]; then
       echo "${name}|${role}|${pid}|alive" >> "$tmp"
     else
       echo "${name}|${role}|${pid}|stopped" >> "$tmp"


### PR DESCRIPTION
zellij run PID is invalid for alive check. Use status file mtime instead (120s threshold).