### PR TITLE
fix: use zellij dump-layout for pane alive check

### DIFF
--- a/scripts/orchestrator.sh
+++ b/scripts/orchestrator.sh
@@ -50,16 +50,14 @@ count_alive() {
 }
 
 update_pane_status() {
+  # Get live pane names from zellij
+  local live_panes
+  live_panes=$(zellij action dump-layout 2>/dev/null | grep 'name="' | grep -v 'tab ' | sed 's/.*name="\([^"]*\)".*/\1/' || echo "")
+
   local tmp="${PANE_REGISTRY}.tmp"; : > "$tmp"
-  local now; now=$(date +%s)
   while IFS='|' read -r name role pid status; do
     [ -z "$name" ] && continue
-    # Check if status file was updated in the last 120 seconds
-    local mtime=0
-    if [ -f "${STATUS_DIR}/${name}.json" ]; then
-      mtime=$(stat -f%m "${STATUS_DIR}/${name}.json" 2>/dev/null || stat -c%Y "${STATUS_DIR}/${name}.json" 2>/dev/null || echo 0)
-    fi
-    if [ $((now - mtime)) -lt 120 ]; then
+    if echo "$live_panes" | grep -qx "$name"; then
       echo "${name}|${role}|${pid}|alive" >> "$tmp"
     else
       echo "${name}|${role}|${pid}|stopped" >> "$tmp"


### PR DESCRIPTION
Query zellij directly for live pane names. Most reliable alive check — no PID or file timestamp heuristics.