### PR TITLE
fix: reliable alive check via status file heartbeat

### DIFF
--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -55,6 +55,7 @@ wait_for_work() {
     implement|watch-issues)
       echo "⏳ Waiting for open issues..."
       while true; do
+        update_status "⏳ waiting" "issues"
         count=$(gh issue list --state open --json number --jq 'length' 2>/dev/null || echo "0")
         [[ "$count" -gt 0 ]] && return 0
         sleep 30
@@ -63,6 +64,7 @@ wait_for_work() {
     review|watch-review)
       echo "⏳ Waiting for open PRs..."
       while true; do
+        update_status "⏳ waiting" "PRs"
         count=$(gh pr list --json number --jq 'length' 2>/dev/null || echo "0")
         [[ "$count" -gt 0 ]] && return 0
         sleep 30
@@ -71,6 +73,7 @@ wait_for_work() {
     fix-review)
       echo "⏳ Waiting for PRs with review comments..."
       while true; do
+        update_status "⏳ waiting" "review comments"
         count=$(gh pr list --json number --jq 'length' 2>/dev/null || echo "0")
         [[ "$count" -gt 0 ]] && return 0
         sleep 30
@@ -79,6 +82,7 @@ wait_for_work() {
     watch-main|e2e-bug-hunt)
       echo "⏳ Waiting for first merge to main..."
       while true; do
+        update_status "⏳ waiting" "merge"
         count=$(gh pr list --state merged --json number --jq 'length' --limit 1 2>/dev/null || echo "0")
         [[ "$count" -gt 0 ]] && return 0
         sleep 30
@@ -87,6 +91,7 @@ wait_for_work() {
     improve)
       echo "⏳ Waiting for first merge to main..."
       while true; do
+        update_status "⏳ waiting" "merge"
         count=$(gh pr list --state merged --json number --jq 'length' --limit 1 2>/dev/null || echo "0")
         [[ "$count" -gt 0 ]] && return 0
         sleep 60

--- a/scripts/orchestrator.sh
+++ b/scripts/orchestrator.sh
@@ -50,14 +50,13 @@ count_alive() {
 }
 
 update_pane_status() {
-  # Get live pane names from zellij
-  local live_panes
-  live_panes=$(zellij action dump-layout 2>/dev/null | grep 'name="' | grep -v 'tab ' | sed 's/.*name="\([^"]*\)".*/\1/' || echo "")
-
   local tmp="${PANE_REGISTRY}.tmp"; : > "$tmp"
+  local now; now=$(date +%s)
   while IFS='|' read -r name role pid status; do
     [ -z "$name" ] && continue
-    if echo "$live_panes" | grep -qx "$name"; then
+    local mtime=0
+    [ -f "${STATUS_DIR}/${name}.json" ] && mtime=$(stat -f%m "${STATUS_DIR}/${name}.json" 2>/dev/null || stat -c%Y "${STATUS_DIR}/${name}.json" 2>/dev/null || echo 0)
+    if [ $((now - mtime)) -lt 60 ]; then
       echo "${name}|${role}|${pid}|alive" >> "$tmp"
     else
       echo "${name}|${role}|${pid}|stopped" >> "$tmp"


### PR DESCRIPTION
Agent heartbeat in wait_for_work + mtime-based alive check in orchestrator. Fixes false 'stopped' display.