### PR TITLE
fix: update.sh self-overwrite crash

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -4,6 +4,10 @@
 #   or:  bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/update.sh)
 set -euo pipefail
 
+# Wrap in a function so bash reads the entire script before executing.
+# This prevents breakage when update.sh overwrites itself mid-run.
+_main() {
+
 REPO="yoshimi-I/kiro-engineer-teams"
 BRANCH="main"
 TMP=$(mktemp -d)
@@ -75,3 +79,5 @@ else
     fi
   fi
 fi
+}
+_main "$@"


### PR DESCRIPTION
update.shが自分自身を上書きした後にbashが残りを読めなくなるバグを修正。全体を関数でラップしてメモリに読み込んでから実行。