### PR TITLE
docs: align issue prompts with pane model

### DIFF
--- a/.kiro/prompts/create-issue.md
+++ b/.kiro/prompts/create-issue.md
@@ -31,6 +31,24 @@ gh issue list --state closed --limit 30 --json number,title
 - 変更方針（ファイルパス付きチェックリスト）
 - テスト、技術的な注意事項、影響範囲、受け入れ条件
 
+### Step 4.5: Pane運用に合わせた分割確認
+`kiro-engineer-teams` は、Orchestratorが必要なpaneだけを短命に起動する。
+issueは「8paneを常時埋める」ためではなく、`implement` paneが迷わず1PRで完了できる粒度に分割する。
+
+分割基準:
+- 1 issue = 1 PR = 1つのユーザー価値、または1つの技術的前提
+- デフォルト運用は `ORCH_MAX_IMPLEMENT=1` 前提。順番に流しても詰まらない依存順にする
+- 並列実行を狙うissueは、変更対象ファイル/ディレクトリが重ならないようにする
+- UI / API / DB / E2E を大きく混ぜない。必要なら別issueに分ける
+- 同じファイルを触るissueは、後続issue本文に `depends-on: #<番号>` を書き `blocked` ラベルを付ける
+- `fix-review` はレビュー指摘時、`e2e-bug-hunt` はmerge後に起動される前提で、通常issueに混ぜすぎない
+- `improve` 向けの曖昧な改善issueは、実装issueが残っている間は増やさない
+
+本文には必ず以下を含める:
+- `## 変更対象`: 主に触るファイル/ディレクトリ
+- `## 触らない範囲`: 競合防止の境界
+- `## 依存関係`: `depends-on: #<番号>` がある場合のみ
+
 ### Step 5: ラベル選定・Issue作成
 `gh issue create` で作成。タイトルはConventional Commits準拠。
 
@@ -39,3 +57,5 @@ gh issue list --state closed --limit 30 --json number,title
 - 調査せずにissueを書かない。最低5ファイルは読む
 - 変更方針のチェックリストは必ずファイルパス付き
 - 大きすぎるissueは分割する。1 issue = 1 PR で完結するスコープに
+- pane数を増やすためにissueを水増ししない。Orchestratorの短命pane運用に合う、独立・小粒・テスト可能なissueにする
+- 変更対象が重なるissueは依存関係を明記し、同時着手されないようにする

--- a/.kiro/skills/inception/references/issue-generation.md
+++ b/.kiro/skills/inception/references/issue-generation.md
@@ -15,6 +15,43 @@ INCEPTIONと8エージェントパイプラインの橋渡し。
 - 単一のPRで実装可能
 - 独立（issue間の依存を最小化）
 - テスト可能（明確な受け入れ基準）
+- 変更対象ファイル・ディレクトリが明確
+- 並列paneで他issueと同時実行しても競合しにくい
+
+#### Pane運用を前提にした分割方針
+
+`kiro-engineer-teams` は8つのpaneを常時起動する前提ではなく、
+Orchestratorが必要な役割paneを短命に起動する前提でissueを供給する。
+
+issue生成時は、pane数を増やすことよりも「実装paneが迷わず1PRで完了できる粒度」を優先する。
+
+基本運用:
+- `implement` はデフォルト同時1pane。issueを小さく、順序付きで流す
+- `fix-review` は `CHANGES_REQUESTED` のPRがある場合のみ起動される
+- `e2e-bug-hunt` はmerge後の検証として起動される
+- `watch-main` / `improve` は任意自動化。初期issue生成ではノイズを増やさない
+
+issue分割ルール:
+- 1 issue = 1 PR = 1つのユーザー価値または1つの技術的前提
+- UI / API / DB / E2E を大きく混ぜない。必要なら依存issueに分ける
+- 複数issueが同じファイルを触る場合は、本文に `depends-on: #<番号>` を書き `blocked` ラベルを付ける
+- 並列化できるissueには、本文の「変更対象」に重複しないファイルパスを明記する
+- scaffold / domain / API contract / implementation / UI / integration / E2E の順に、上流から下流へ作る
+- `improve` が拾うような曖昧な改善はINCEPTION直後に大量生成しない。実装issueが枯れてから扱う
+
+良い分割例:
+- `chore: scaffold frontend app`
+- `chore: scaffold backend app`
+- `feat: add user domain model and validation`
+- `feat: add auth API contract`
+- `feat: implement login API`
+- `feat: implement login screen`
+- `test: add login E2E flow`
+
+悪い分割例:
+- `feat: implement authentication`
+- `feat: build dashboard`
+- `feat: connect frontend and backend and add tests`
 
 ### 3. 優先順位付け
 1. プロジェクトセットアップ / スキャフォールディング（最初に必須）
@@ -42,6 +79,13 @@ gh issue create \
 
 ## 技術メモ
 <関連するアーキテクチャ決定、ファイルパス、依存関係>
+
+## 変更対象
+- <主に変更するファイル/ディレクトリ>
+- <触らないファイル/境界があれば明記>
+
+## 依存関係
+- depends-on: #<番号>（必要な場合のみ）
 
 ## 参照
 - 要件: aidlc-docs/inception/requirements/requirements.md


### PR DESCRIPTION
issue生成プロンプトをOrchestrator短命pane運用に合わせて更新
- 分割基準にpane競合回避・依存関係明記を追加
- issueテンプレートに変更対象/依存関係セクション追加