### PR TITLE
fix: harden gh cache and add planner diagnostics

### DIFF
--- a/scripts/lib/github.sh
+++ b/scripts/lib/github.sh
@@ -3,12 +3,41 @@
 gh_cached() {
   local key="$1"; shift
   local cache_file="${CACHE_DIR}/${key}"
+  local err_file="${CACHE_DIR}/${key}.err"
   if [ -f "$cache_file" ]; then
     local age=$(( $(date +%s) - $(stat -f%m "$cache_file" 2>/dev/null || stat -c%Y "$cache_file" 2>/dev/null || echo 0) ))
-    [ $age -lt $CACHE_TTL ] && cat "$cache_file" && return
+    if [ $age -lt $CACHE_TTL ]; then
+      case "$key" in
+        issues_json|prs_json)
+          jq -e 'type == "array"' "$cache_file" >/dev/null 2>&1 && cat "$cache_file" && return
+          ;;
+        gh_user|latest_merged_pr)
+          [ "$(cat "$cache_file")" != "0" ] && cat "$cache_file" && return
+          ;;
+        *)
+          cat "$cache_file" && return
+          ;;
+      esac
+    fi
   fi
-  local result; result=$("$@" 2>/dev/null || echo "0")
-  echo "$result" > "$cache_file"; echo "$result"
+
+  local default result
+  case "$key" in
+    issues_json|prs_json) default="[]" ;;
+    latest_merged_pr|gh_user) default="" ;;
+    *) default="0" ;;
+  esac
+
+  if result=$("$@" 2>"$err_file"); then
+    rm -f "$err_file"
+    echo "$result" > "$cache_file"
+    echo "$result"
+    return
+  fi
+
+  # Keep the UI structurally valid even when gh auth/network is broken.
+  echo "$default" > "$cache_file"
+  echo "$default"
 }
 
 refresh_github() {

--- a/scripts/lib/planner.sh
+++ b/scripts/lib/planner.sh
@@ -304,6 +304,7 @@ ai_plan() {
 
 Context JSON:
 $context" 2>/dev/null || true)
+  printf '%s\n' "$raw" > "${CACHE_DIR}/orchestrator_plan.raw"
   plan=$(printf '%s\n' "$raw" | extract_json_object)
   if jq -e '.actions and (.actions | type == "array")' >/dev/null 2>&1 <<< "$plan"; then
     printf '%s\n' "$plan" > "$AI_PLAN_FILE"
@@ -529,7 +530,25 @@ fallback_scale() {
   if [ -n "$launched" ]; then
     record_decision "fallback" "launched:${launched# }" "conservative rule matched"
   else
-    record_decision "fallback" "idle" "no rule matched"
+    local idle_detail=""
+    if [ "$AUTO_DEV_SERVER" != "true" ]; then
+      idle_detail="${idle_detail} dev-server automation disabled;"
+    elif ! has_dev_target; then
+      idle_detail="${idle_detail} no dev target;"
+    elif role_active "dev-server"; then
+      idle_detail="${idle_detail} dev-server already active;"
+    else
+      idle_detail="${idle_detail} dev-server launch not needed;"
+    fi
+    [ "${READY_ISSUES:-0}" -le 0 ] && idle_detail="${idle_detail} no ready issues;"
+    [ -z "$(next_review_pr_number)" ] && idle_detail="${idle_detail} no reviewable PRs;"
+    [ -z "$(next_fix_review_pr_number)" ] && idle_detail="${idle_detail} no requested-change PRs;"
+    if ! post_merge_due; then
+      idle_detail="${idle_detail} no new post-merge work;"
+    elif ! role_active "dev-server"; then
+      idle_detail="${idle_detail} post-merge work waits for dev-server;"
+    fi
+    record_decision "fallback" "idle" "${idle_detail# }"
   fi
 }
 

--- a/scripts/lib/render.sh
+++ b/scripts/lib/render.sh
@@ -23,6 +23,13 @@ render() {
     fi
   fi
   echo -e "  \033[35m🧠 ${LAST_PLAN_SOURCE}\033[0m  ${LAST_DECISION_SUMMARY}  \033[2m${LAST_DECISION_DETAIL} (${LAST_DECISION_TS:---:--:--}) next:${TICK_INTERVAL}s\033[0m"
+  local gh_err
+  gh_err=$(find "$CACHE_DIR" -maxdepth 1 -name '*.err' -type f -print -quit 2>/dev/null)
+  if [ -n "$gh_err" ]; then
+    local gh_msg
+    gh_msg=$(tr '\n' ' ' < "$gh_err" | sed 's/[[:space:]][[:space:]]*/ /g' | cut -c1-140)
+    echo -e "  \033[33m⚠ github:\033[0m \033[2m${gh_msg}\033[0m"
+  fi
   if [ -f "${OPERATOR_REQUEST_FILE:-}" ]; then
     local op_status op_request op_target
     op_status=$(jq -r '.status // "empty"' "$OPERATOR_REQUEST_FILE" 2>/dev/null || echo invalid)
@@ -127,6 +134,17 @@ render() {
     echo -e "  \033[32mActions:\033[0m \033[2m${actions}\033[0m"
     echo -e "  \033[31mStops:\033[0m \033[2m${stops}\033[0m"
     echo -e "  \033[33mSkipped:\033[0m \033[2m${skips:0:140}\033[0m"
+    echo ""
+  elif [ -f "${CACHE_DIR}/orchestrator_plan.raw" ] || [ -f "$DECISION_FILE" ]; then
+    echo -e "  \033[1m🧠 Planner Diagnostics\033[0m"
+    echo -e "  \033[35mSource:\033[0m \033[2m${LAST_PLAN_SOURCE}\033[0m"
+    echo -e "  \033[32mDecision:\033[0m \033[2m${LAST_DECISION_SUMMARY} ${LAST_DECISION_DETAIL}\033[0m"
+    if [ -f "${CACHE_DIR}/orchestrator_plan.raw" ]; then
+      local raw_preview
+      raw_preview=$(tr '\n' ' ' < "${CACHE_DIR}/orchestrator_plan.raw" | sed 's/[[:space:]][[:space:]]*/ /g' | cut -c1-180)
+      [ -n "$raw_preview" ] || raw_preview="empty response from AI planner"
+      echo -e "  \033[33mAI raw:\033[0m \033[2m${raw_preview}\033[0m"
+    fi
     echo ""
   fi
 }


### PR DESCRIPTION
## Changes
- gh_cachedのキャッシュ検証を強化（JSON構造チェック、API失敗時の安全なデフォルト値）
- gh CLIエラーを.errファイルに保存しUI上に警告表示
- fallback idle時の詳細理由表示を追加
- AIプランナーのraw応答を保存しdiagnosticsセクションで表示