### PR TITLE
fix: ready issues returns 0 when GH_USER is empty

### DIFF
--- a/scripts/lib/github.sh
+++ b/scripts/lib/github.sh
@@ -48,7 +48,10 @@ refresh_github() {
   ISSUES=$(jq 'length' <<< "${ISSUES_JSON:-[]}" 2>/dev/null || echo 0)
   READY_ISSUES=$(jq --arg me "${GH_USER:-}" '
     [.[].number] as $open
-    | [.[] | select((.assignees | length == 0) or ([.assignees[]?.login] | index($me)))
+    | [.[] | select(
+        (.assignees | length == 0)
+        or ($me != "" and ([.assignees[]?.login] | index($me)))
+        or ($me == ""))
       | select(([.labels[]?.name] | index("blocked") | not))
       | select(((.body // "" | [scan("depends-on: *#([0-9]+)") | .[0] | tonumber]) as $deps
         | ([$deps[] | select(. as $d | $open | index($d))] | length) == 0))]

--- a/scripts/lib/planner.sh
+++ b/scripts/lib/planner.sh
@@ -53,7 +53,7 @@ fix_review_pr_numbers_json() {
   active=$(active_pr_numbers_json "fix-review" "fix-review")
   jq --arg me "${GH_USER:-}" --argjson active "$active" '
     [.[] | select(.reviewDecision == "CHANGES_REQUESTED")
-      | select((.assignees | length == 0) or ([.assignees[]?.login] | index($me)))
+      | select((.assignees | length == 0) or ($me != "" and ([.assignees[]?.login] | index($me))) or ($me == ""))
       | select((.number as $n | $active | index($n) | not))
       | .number]
   ' <<< "${PRS_JSON:-[]}" 2>/dev/null || echo "[]"
@@ -79,7 +79,10 @@ ready_issue_numbers_json() {
     --arg me "${GH_USER:-}" \
     --argjson active "$active" '
     [.[].number] as $open
-    | [.[] | select((.assignees | length == 0) or ([.assignees[]?.login] | index($me)))
+    | [.[] | select(
+        (.assignees | length == 0)
+        or ($me != "" and ([.assignees[]?.login] | index($me)))
+        or ($me == ""))
       | select(([.labels[]?.name] | index("blocked") | not))
       | select((.number as $n | $active | index($n) | not))
       | select(((.body // "" | [scan("depends-on: *#([0-9]+)") | .[0] | tonumber]) as $deps
@@ -271,7 +274,10 @@ build_ai_context() {
         unassigned_count: ([$issues[] | select(.assignees | length == 0)] | length),
         ready_count: (
           [$issues[].number] as $open
-          | [$issues[] | select((.assignees | length == 0) or ([.assignees[]?.login] | index($me)))
+          | [$issues[] | select(
+              (.assignees | length == 0)
+              or ($me != "" and ([.assignees[]?.login] | index($me)))
+              or ($me == ""))
             | select(([.labels[]?.name] | index("blocked") | not))
             | select(((.body // "" | [scan("depends-on: *#([0-9]+)") | .[0] | tonumber]) as $deps
               | ([$deps[] | select(. as $d | $open | index($d))] | length) == 0))]


### PR DESCRIPTION
## Problem
`GH_USER`が空のとき、全アサイン済みissueがreadyフィルタで除外され、ready=0になりpaneが起動しなかった。

## Root Cause
`gh api user`が失敗すると`GH_USER=''`になり、jqの`index('')`はnullを返すため、アサイン済みissueが全て除外される。

## Fix
`GH_USER`が空の場合はアサイン状態に関わらず全issueをready候補に含める。4箇所の同一パターンを修正。