### PR TITLE
fix: keep agent panes visible after completion

### DIFF
--- a/scripts/control-panel.sh
+++ b/scripts/control-panel.sh
@@ -93,10 +93,10 @@ open_agent_pane() {
   local tab_id pane
   tab_id=$(agents_tab_id)
   if [[ -n "$tab_id" && "$tab_id" != "null" ]]; then
-    pane=$(zellij action new-pane --tab-id "$tab_id" --name "$selection" --cwd "$(pwd)" --close-on-exit \
+    pane=$(zellij action new-pane --tab-id "$tab_id" --name "$selection" --cwd "$(pwd)" \
       -- bash -lc "AGENT_ID='${selection}' AGENT_ONCE=true AGENT_INTERVAL=10 ./scripts/agent.sh '${prompt}'")
   else
-    pane=$(zellij action new-pane --name "$selection" --cwd "$(pwd)" --close-on-exit \
+    pane=$(zellij action new-pane --name "$selection" --cwd "$(pwd)" \
       -- bash -lc "AGENT_ID='${selection}' AGENT_ONCE=true AGENT_INTERVAL=10 ./scripts/agent.sh '${prompt}'")
   fi
   zellij action rename-pane --pane-id "$pane" "$selection" 2>/dev/null || true

--- a/scripts/lib/panes.sh
+++ b/scripts/lib/panes.sh
@@ -257,10 +257,10 @@ add_pane() {
   context_b64=$(agent_arg_b64 "$context")
   reason_b64=$(agent_arg_b64 "$reason")
   if [ -n "$AGENTS_TAB_ID" ] && [ "$AGENTS_TAB_ID" != "null" ]; then
-    pane=$(zellij action new-pane --tab-id "$AGENTS_TAB_ID" --name "$name" --cwd "$PROJECT_CWD" --close-on-exit \
+    pane=$(zellij action new-pane --tab-id "$AGENTS_TAB_ID" --name "$name" --cwd "$PROJECT_CWD" \
       -- bash -lc "AGENT_ID='${name}' AGENT_CONTEXT_B64='${context_b64}' AGENT_REASON_B64='${reason_b64}' AGENT_ONCE=true AGENT_INTERVAL=30 ./scripts/agent.sh '${role}'")
   else
-    pane=$(zellij action new-pane --name "$name" --cwd "$PROJECT_CWD" --close-on-exit \
+    pane=$(zellij action new-pane --name "$name" --cwd "$PROJECT_CWD" \
       -- bash -lc "AGENT_ID='${name}' AGENT_CONTEXT_B64='${context_b64}' AGENT_REASON_B64='${reason_b64}' AGENT_ONCE=true AGENT_INTERVAL=30 ./scripts/agent.sh '${role}'")
   fi
   if [ -z "$pane" ] || ! pane_exists "$pane"; then


### PR DESCRIPTION
agent paneが--close-on-exitで終了後即消えてzellij UIに表示されなかった問題を修正