### PR TITLE
chore: rename project to ai-engineer-teams + add claude-review CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-# Bash-centric CI for the kiro-engineer-teams template itself.
+# Bash-centric CI for the ai-engineer-teams template itself.
 #
 # The runtime of this repo is bash scripts + zellij + gh; there is no Node,
 # Python, or Go toolchain to bootstrap. This workflow runs the same three

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,57 @@
+name: Claude Review
+
+# Claude Code review running in parallel with kiro-review.yml so users on
+# either runner get an automated review on develop-bound PRs.
+#
+# Two modes:
+#   1. Automatic: every PR opened/synchronized against `develop` is reviewed.
+#   2. On-demand: comment `@claude` on a PR (or `/claude-review`) to trigger
+#      a fresh review.
+#
+# Setup:
+#   - Repo Settings → Secrets → add ANTHROPIC_API_KEY (from console.anthropic.com).
+#   - The action authenticates with that key only — no OAuth needed.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [develop]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only run on develop-bound PRs (auto), or when @claude / /claude-review
+    # is mentioned in a PR comment / review comment.
+    if: >-
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.base.ref == 'develop') ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (contains(github.event.comment.body, '@claude') ||
+         contains(github.event.comment.body, '/claude-review'))) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        (contains(github.event.comment.body, '@claude') ||
+         contains(github.event.comment.body, '/claude-review')))
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Trigger phrase for comment-based invocations. Pull-request events
+          # always run regardless of trigger_phrase.
+          trigger_phrase: "@claude"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.kiro/agents/default.json
+++ b/.kiro/agents/default.json
@@ -1,6 +1,6 @@
 {
   "name": "default",
-  "description": "Kiro Engineer Teams pipeline default agent",
+  "description": "AI Engineer Teams pipeline default agent",
   "tools": ["*"],
   "resources": [
     "file://AGENTS.md",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Kiro Engineer Teams
+# AI Engineer Teams
 
 Auto-scaling agent development pipeline with AI-DLC INCEPTION planning.
 The orchestrator starts minimal and spawns additional zellij panes on

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# 🏭 kiro-engineer-teams
+# 🏭 ai-engineer-teams
 
 **Auto-scaling agent development pipeline**
 **powered by [Kiro CLI](https://kiro.dev/docs/cli/) × [zellij](https://zellij.dev/)**
@@ -23,7 +23,7 @@ issue → implementation → review → merge → E2E verification — fully aut
 ```bash
 mkdir <your-project>
 cd <your-project>
-git clone https://github.com/yoshimi-I/kiro-engineer-teams.git .
+git clone https://github.com/yoshimi-I/ai-engineer-teams.git .
 ```
 
 **2. Install prerequisites**
@@ -44,7 +44,7 @@ Use `just restart` to clear local agent runtime state and restart from the first
 ## 📥 Add to Existing Project
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/ai-engineer-teams/main/scripts/install.sh)
 just setup && just start
 ```
 
@@ -114,30 +114,41 @@ just start (./scripts/start-pipeline.sh)
 
 ---
 
-## 🤖 CI + Kiro Review
+## 🤖 CI Reviews (Kiro and Claude Code)
 
-PRs are automatically reviewed by [kiro-cli-review-action](https://github.com/konippi/kiro-cli-review-action) on GitHub Actions.
+Two parallel review workflows ship out of the box. Either or both can run;
+configure whichever runner you use (or both):
+
+| Workflow | Action | Required secret |
+|----------|--------|-----------------|
+| `.github/workflows/kiro-review.yml`   | [konippi/kiro-cli-review-action](https://github.com/konippi/kiro-cli-review-action) | `KIRO_API_KEY` from [app.kiro.dev](https://app.kiro.dev) |
+| `.github/workflows/claude-review.yml` | [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action) | `ANTHROPIC_API_KEY` from [console.anthropic.com](https://console.anthropic.com) |
 
 **Setup:**
-1. Get a `KIRO_API_KEY` from [app.kiro.dev](https://app.kiro.dev)
-2. `just start` will prompt you to set it, or manually: `gh secret set KIRO_API_KEY`
-3. The workflow runs automatically on PR creation
 
-```yaml
-# .github/workflows/kiro-review.yml
-- uses: konippi/kiro-cli-review-action@v1
-  with:
-    kiro_api_key: ${{ secrets.KIRO_API_KEY }}
-    trigger_phrase: /review          # comment "/review" on a PR for on-demand review
-  env:
-    GITHUB_TOKEN: ${{ github.token }} # required for GitHub MCP server
+```bash
+# Whichever runners you plan to use:
+gh secret set KIRO_API_KEY        # for kiro-review.yml
+gh secret set ANTHROPIC_API_KEY   # for claude-review.yml
 ```
 
-> ⚠️ `GITHUB_TOKEN` must be passed via `env`. Without it, the GitHub MCP server fails to start and reviews won't be posted.
+Both workflows trigger on `develop`-bound PRs and respond to on-demand
+comments:
 
-> ⚠️ Do not use `@kiro` as trigger phrase — it sends a mention notification to an unrelated GitHub user.
+| Trigger | Kiro | Claude |
+|---------|:-:|:-:|
+| `develop` PR opened / updated | auto | auto |
+| `/review` PR comment          | ✅   | —   |
+| `@claude` PR comment          | —    | ✅  |
+| `/claude-review` PR comment   | —    | ✅  |
 
-| Role | CI Kiro Review | Local Review Agent |
+> ⚠️ `GITHUB_TOKEN` must be passed via `env` for the kiro action.
+> Without it, the GitHub MCP server fails to start and reviews won't be posted.
+
+> ⚠️ Do not use `@kiro` as a trigger phrase — it sends a mention notification
+> to an unrelated GitHub user. Use `/review` for the kiro workflow.
+
+| Role | CI Reviews (Kiro / Claude) | Local Review Agent |
 |------|:-:|:-:|
 | Code review | ✅ | — |
 | Merge approved PRs | — | ✅ |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# 🏭 kiro-engineer-teams
+# 🏭 ai-engineer-teams
 
 **動的スケーリング型エージェント開発パイプライン**
 **[Kiro CLI](https://kiro.dev/docs/cli/) × [zellij](https://zellij.dev/)**
@@ -23,7 +23,7 @@ issue → 実装 → レビュー → マージ → E2E検証を全自動化。
 ```bash
 mkdir <your-project>
 cd <your-project>
-git clone https://github.com/yoshimi-I/kiro-engineer-teams.git .
+git clone https://github.com/yoshimi-I/ai-engineer-teams.git .
 ```
 
 **2. 前提ツールをインストール**
@@ -48,7 +48,7 @@ just start
 既にプロジェクトがある場合、プロジェクトルートでこのワンライナーを実行：
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/ai-engineer-teams/main/scripts/install.sh)
 ```
 
 `.kiro/`、`scripts/`、`justfile`、`AGENTS.md`、`skills-lock.json` がコピーされます。既存ファイルは上書きされません。

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# kiro-engineer-teams
+# ai-engineer-teams
 
 # Install prerequisites (kiro-cli, zellij, gh, gum, jq)
 setup:
@@ -44,7 +44,7 @@ restart:
 
 # Install into existing project (run from target project root)
 install:
-    bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/install.sh)
+    bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/ai-engineer-teams/main/scripts/install.sh)
 
 # Switch to Japanese
 ja:

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# One-shot scaffold: turn a fresh clone of the kiro-engineer-teams template
+# One-shot scaffold: turn a fresh clone of the ai-engineer-teams template
 # into a new GitHub repository for your own project.
 #
 # This script is destructive by design: it removes template-only files
@@ -27,11 +27,11 @@ warn() { echo -e "${YELLOW}  ⚠ $1${RESET}"; }
 fail() { echo -e "${RED}  ✗ $1${RESET}"; exit 1; }
 
 echo ""
-echo -e "${BOLD}  🚀 kiro-engineer-teams — scaffold new project${RESET}"
+echo -e "${BOLD}  🚀 ai-engineer-teams — scaffold new project${RESET}"
 echo ""
 
 # ── Guard: only run from an upstream clone ─────────────────────────────────
-UPSTREAM_TEMPLATE_REGEX='(^|[:/])yoshimi-I/kiro-engineer-teams(\.git)?/?$'
+UPSTREAM_TEMPLATE_REGEX='(^|[:/])yoshimi-I/ai-engineer-teams(\.git)?/?$'
 REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
 
 HAS_UPSTREAM_ORIGIN=false
@@ -40,7 +40,7 @@ if [[ -n "$REMOTE_URL" && "$REMOTE_URL" =~ $UPSTREAM_TEMPLATE_REGEX ]]; then
 fi
 
 HAS_TEMPLATE_MARKER=false
-if [[ -f README.md ]] && grep -q "kiro-engineer-teams" README.md 2>/dev/null; then
+if [[ -f README.md ]] && grep -q "ai-engineer-teams" README.md 2>/dev/null; then
   HAS_TEMPLATE_MARKER=true
 fi
 
@@ -54,7 +54,7 @@ if [[ "$HAS_UPSTREAM_ORIGIN" != "true" && "$HAS_TEMPLATE_MARKER" != "true" ]]; t
   echo "  Refusing to run on what appears to be an existing project."
   echo ""
   echo "  If you are sure this is intended, clone the template fresh first:"
-  echo "    git clone https://github.com/yoshimi-I/kiro-engineer-teams.git <dir>"
+  echo "    git clone https://github.com/yoshimi-I/ai-engineer-teams.git <dir>"
   echo "    cd <dir> && ./scripts/init.sh"
   exit 1
 fi
@@ -89,7 +89,7 @@ echo "    - .git/ ディレクトリ全体 (履歴を初期化)"
 echo ""
 echo "  その後、新しい git 履歴で以下を作成します:"
 echo "    - GitHub リポジトリ: $REPO (private)"
-echo "    - 初期コミット: 'init: scaffold from kiro-engineer-teams'"
+echo "    - 初期コミット: 'init: scaffold from ai-engineer-teams'"
 echo ""
 read -r -p "  本当に続行しますか？ (y/N) → " CONFIRM
 if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
@@ -102,14 +102,14 @@ echo ""
 rm -f LICENSE
 rm -rf docs
 for f in README.md AGENTS.md; do
-  grep -q "kiro-engineer-teams" "$f" 2>/dev/null && rm -f "$f"
+  grep -q "ai-engineer-teams" "$f" 2>/dev/null && rm -f "$f"
 done
 
 # ── Initialize git & create repo ───────────────────────────────────────────
 rm -rf .git
 git init -q
 git add .
-git commit -q -m "init: scaffold from kiro-engineer-teams"
+git commit -q -m "init: scaffold from ai-engineer-teams"
 gh repo create "$REPO" --private --source=. --push > /dev/null 2>&1
 
 echo -e "${GREEN}  ✔ $REPO を作成しました${RESET}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Install kiro-engineer-teams into an existing project.
+# Install ai-engineer-teams into an existing project.
 # Usage: curl -fsSL <raw-url>/scripts/install.sh | bash
 #    or: bash <(curl -fsSL <raw-url>/scripts/install.sh)
 
 set -euo pipefail
 
-REPO="yoshimi-I/kiro-engineer-teams"
+REPO="yoshimi-I/ai-engineer-teams"
 BRANCH="main"
 BOLD='\033[1m' DIM='\033[2m' GREEN='\033[32m' RED='\033[31m' YELLOW='\033[33m' RESET='\033[0m'
 
@@ -14,8 +14,8 @@ warn()  { echo -e "${YELLOW}  ⚠ $1${RESET}"; }
 fail()  { echo -e "${RED}  ✗ $1${RESET}"; exit 1; }
 
 echo ""
-echo -e "${BOLD}  📦 Install kiro-engineer-teams${RESET}"
-echo -e "${DIM}  Add the Kiro Engineer Teams pipeline to your existing project${RESET}"
+echo -e "${BOLD}  📦 Install ai-engineer-teams${RESET}"
+echo -e "${DIM}  Add the AI Engineer Teams pipeline to your existing project${RESET}"
 echo ""
 
 # ── Preflight ──
@@ -57,6 +57,7 @@ echo ""
 copy_dir ".kiro"
 copy_dir "scripts"
 copy_file ".github/workflows/kiro-review.yml"
+copy_file ".github/workflows/claude-review.yml"
 copy_file ".github/workflows/promote-main.yml"
 copy_file ".github/PULL_REQUEST_TEMPLATE.md"
 copy_file ".github/ISSUE_TEMPLATE/bug_report.md"
@@ -66,7 +67,7 @@ copy_file ".github/ISSUE_TEMPLATE/feature_request.md"
 RECIPES=("setup" "preflight" "start" "restart" "pipeline" "ja" "en")
 RECIPE_BLOCKS=$(cat <<'JUST'
 
-# ── kiro-engineer-teams ──
+# ── ai-engineer-teams ──
 
 # Install prerequisites
 setup:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install prerequisites for the kiro-engineer-teams pipeline.
+# Install prerequisites for the ai-engineer-teams pipeline.
 #
 # This script ONLY installs tools (kiro-cli, zellij, gh, gum, jq, shellcheck,
 # bats-core, fswatch). It never removes user files. Template cleanup is
@@ -9,7 +9,7 @@
 #
 # Before this change, this script ran an unconditional rm on LICENSE,
 # README.md, docs/README.ja.md, and docs/ whenever those files contained
-# the string "kiro-engineer-teams". That made `just setup` destroy
+# the string "ai-engineer-teams". That made `just setup` destroy
 # documentation and license files on a fresh clone — directly opposite
 # to what the Quick Start in README.md promises ("clone → just setup").
 #

--- a/scripts/start-pipeline.sh
+++ b/scripts/start-pipeline.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Kiro Engineer Teams Pipeline Launcher
+# AI Engineer Teams Pipeline Launcher
 #
 # Phase 1: INCEPTION — structured planning with AI-DLC workflow
 # Phase 2: Pipeline — launch agents in zellij
@@ -130,12 +130,12 @@ fi
 # ── Check if this is the upstream template repo itself ──
 # We only trigger the scaffold-new-repo flow when the origin URL matches the
 # canonical upstream repository exactly. Matching on the substring
-# "kiro-engineer-teams" would also fire for forks and unrelated repos that
-# happen to contain the same string in their URL (e.g. myorg/kiro-engineer-teams-playground).
+# "ai-engineer-teams" would also fire for forks and unrelated repos that
+# happen to contain the same string in their URL (e.g. myorg/ai-engineer-teams-playground).
 # That misfire would delete LICENSE / docs / README and replace origin — highly
 # destructive on a fork.
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
-UPSTREAM_TEMPLATE_REGEX='(^|[:/])yoshimi-I/kiro-engineer-teams(\.git)?/?$'
+UPSTREAM_TEMPLATE_REGEX='(^|[:/])yoshimi-I/ai-engineer-teams(\.git)?/?$'
 IS_UPSTREAM_TEMPLATE=false
 if [[ "$REMOTE_URL" =~ $UPSTREAM_TEMPLATE_REGEX ]]; then
   IS_UPSTREAM_TEMPLATE=true
@@ -174,7 +174,7 @@ if [[ "$IS_UPSTREAM_TEMPLATE" == "true" ]]; then
     rm -f LICENSE
     rm -rf docs
     for f in README.md AGENTS.md; do
-      grep -q "kiro-engineer-teams" "$f" 2>/dev/null && rm -f "$f"
+      grep -q "ai-engineer-teams" "$f" 2>/dev/null && rm -f "$f"
     done
 
     # Wipe the template's git history so the new project starts from a single
@@ -191,7 +191,7 @@ if [[ "$IS_UPSTREAM_TEMPLATE" == "true" ]]; then
     GIT_AUTHOR_EMAIL="$INIT_AUTHOR_EMAIL" \
     GIT_COMMITTER_NAME="$INIT_AUTHOR_NAME" \
     GIT_COMMITTER_EMAIL="$INIT_AUTHOR_EMAIL" \
-      git commit -q -m "init: scaffold from kiro-engineer-teams" --allow-empty
+      git commit -q -m "init: scaffold from ai-engineer-teams" --allow-empty
 
     # Create the remote repo and push the single init commit.
     gh repo create "$REPO_NAME" $VIS_FLAG --source=. --remote origin --push

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Update kiro-engineer-teams to the latest version
+# Update ai-engineer-teams to the latest version
 # Usage: ./scripts/update.sh
-#   or:  bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/kiro-engineer-teams/main/scripts/update.sh)
+#   or:  bash <(curl -fsSL https://raw.githubusercontent.com/yoshimi-I/ai-engineer-teams/main/scripts/update.sh)
 set -euo pipefail
 
-REPO="yoshimi-I/kiro-engineer-teams"
+REPO="yoshimi-I/ai-engineer-teams"
 BRANCH="${1:-main}"
 if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "develop" ]; then
   echo "Usage: ./scripts/update.sh [main|develop]"
@@ -13,16 +13,17 @@ fi
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-echo "🔄 Updating kiro-engineer-teams..."
+echo "🔄 Updating ai-engineer-teams..."
 echo ""
 
 # Download latest
 curl -fsSL "https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz" | tar xz -C "$TMP"
-SRC="${TMP}/kiro-engineer-teams-${BRANCH}"
+SRC="${TMP}/ai-engineer-teams-${BRANCH}"
 
 # Files to update (overwrite) — update.sh is excluded and handled last
 TARGETS=(
   ".github/workflows/kiro-review.yml"
+  ".github/workflows/claude-review.yml"
   ".github/workflows/promote-main.yml"
   ".github/PULL_REQUEST_TEMPLATE.md"
   ".github/ISSUE_TEMPLATE/bug_report.md"
@@ -92,7 +93,7 @@ else
   read -r -p "  この変更をコミットしますか？ (Y/n) → " yn
   if [ "$yn" != "n" ] && [ "$yn" != "N" ]; then
     git add -A
-    git commit --no-verify -m "chore: update kiro-engineer-teams pipeline"
+    git commit --no-verify -m "chore: update ai-engineer-teams pipeline"
     echo "  ✔ コミットしました。"
     read -r -p "  プッシュしますか？ (Y/n) → " yn2
     if [ "$yn2" != "n" ] && [ "$yn2" != "N" ]; then


### PR DESCRIPTION
## Summary

- Rename the project from `kiro-engineer-teams` to `ai-engineer-teams` (GitHub repo already renamed via `gh repo rename`). Title-case "Kiro Engineer Teams" → "AI Engineer Teams" everywhere it appears in user-facing docs and the default agent description.
- Add `.github/workflows/claude-review.yml` running `anthropics/claude-code-action@v1` in parallel with the existing `kiro-review.yml`, so users on either runner get an automated PR review.

What is intentionally **not** renamed (each is load-bearing for an external system):
- `KIRO_*` env vars (`KIRO_AI_RUNNER`, `KIRO_INTEGRATION_BRANCH`, `KIRO_API_KEY`, …) — `KIRO_API_KEY` is required by `konippi/kiro-cli-review-action`, and renaming only the others would split the env-var namespace.
- `.kiro/` directory — kiro-cli reads this path natively.
- `kiro-cli`, `kiro.dev`, `kiro-review.yml` — refer to the upstream tool, not this project.

## Test plan

- [x] `bash scripts/check.sh` exits 0 (65/65 bats, shellcheck clean, syntax clean).
- [x] No collateral damage on protected strings (`KIRO_*` env vars, `.kiro/`, `kiro-cli`, `kiro.dev`, `kiro-review.yml`) — verified via grep.
- [ ] Existing template consumers run `./scripts/update.sh` and pick up `.github/workflows/claude-review.yml` automatically.
- [ ] On-demand `@claude` PR comment triggers `claude-review.yml` on a real PR (requires `ANTHROPIC_API_KEY` secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)