### PR TITLE
fix(setup): handle invalid GITHUB_TOKEN before calling gh auth login

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -101,8 +101,18 @@ else
 fi
 
 # ── gh auth ──
+# `gh auth login` refuses to run interactively when GITHUB_TOKEN is set in
+# the environment, even if that token is invalid or lacks scopes. Detect
+# that combination explicitly so the user gets a clear instruction instead
+# of an opaque "first clear the value from the environment" message that
+# appears mid-prompt and then exits 1.
 if gh auth status &>/dev/null; then
   info "gh authenticated"
+elif [ -n "${GITHUB_TOKEN:-}" ]; then
+  warn "GITHUB_TOKEN is set but gh cannot authenticate with it (token may be invalid or lacks required scopes)."
+  warn "Unset it (or replace it with a valid token) and re-run setup:"
+  echo "    unset GITHUB_TOKEN && just setup"
+  exit 1
 else
   warn "gh not authenticated. Running: gh auth login"
   gh auth login


### PR DESCRIPTION
## Summary

closes #166

`gh auth login` refuses to run interactively when `GITHUB_TOKEN` is set in the environment. With an invalid or revoked token in `GITHUB_TOKEN` (common on macOS via launchctl / direnv / zshrc), the previous flow:

```bash
if gh auth status &>/dev/null; then ...
else gh auth login; fi
```

would hit the `gh auth login` branch, gh would print a one-line "first clear the value from the environment" message mid-prompt and exit 1, taking `just setup` down with it. The user sees an opaque crash with no actionable next step.

This PR adds an explicit `elif [ -n "${GITHUB_TOKEN:-}" ]` branch that prints a clear instruction (`unset GITHUB_TOKEN && just setup`) and exits cleanly.

## Test plan

- [x] `bash scripts/check.sh` exits 0 (65/65 bats, shellcheck clean).
- [x] Smoke test of the branch logic in isolation (4 cases: auth-ok ± token, auth-fail ± token) — all four take the expected branch.
- [ ] Reproduce on the original repro: `export GITHUB_TOKEN=ghp_invalid && just setup` → script now exits with the unset-and-rerun instruction instead of dropping into a doomed `gh auth login` prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)