### PR TITLE
fix(scripts): generalize GITHUB_TOKEN keychain fallback to start-pipeline & preflight

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -54,6 +54,14 @@ fi
 
 if gh auth status >/dev/null 2>&1; then
   ok "gh authenticated"
+elif [ -n "${GITHUB_TOKEN:-}" ] && env -u GITHUB_TOKEN gh auth status >/dev/null 2>&1; then
+  # GITHUB_TOKEN is set but stale; keychain credentials are still valid. See
+  # the matching fallback in setup.sh / start-pipeline.sh and #166 / #168.
+  # unset the bad env var so the rest of preflight (and the orchestrator
+  # that follows) uses the keychain.
+  warn "GITHUB_TOKEN is set but invalid; falling back to gh keychain credentials"
+  unset GITHUB_TOKEN
+  ok "gh authenticated (via keychain)"
 else
   fail "gh is not authenticated. Run: gh auth login"
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -101,16 +101,26 @@ else
 fi
 
 # ── gh auth ──
-# `gh auth login` refuses to run interactively when GITHUB_TOKEN is set in
-# the environment, even if that token is invalid or lacks scopes. Detect
-# that combination explicitly so the user gets a clear instruction instead
-# of an opaque "first clear the value from the environment" message that
-# appears mid-prompt and then exits 1.
+# `gh` consults GITHUB_TOKEN before the keychain. If the env var holds a
+# stale/invalid token while the keychain has valid credentials, the user
+# can authenticate just fine via `unset GITHUB_TOKEN && gh ...` but
+# `just setup` itself died because `gh auth login` refuses to launch the
+# interactive flow while GITHUB_TOKEN is set (see #166 / #168). Handle
+# each case explicitly:
+#   (1) gh already auths with whatever it sees → done.
+#   (2) Env-var token is bad but keychain works → unset locally, continue.
+#   (3) Env-var token is the only auth and it is bad → ask the user to fix it.
+#   (4) No auth at all → interactive login.
 if gh auth status &>/dev/null; then
   info "gh authenticated"
+elif [ -n "${GITHUB_TOKEN:-}" ] && env -u GITHUB_TOKEN gh auth status &>/dev/null; then
+  warn "GITHUB_TOKEN in your shell is invalid; falling back to gh keychain credentials for this run."
+  warn "Fix it in your shell init (~/.zshrc, ~/.bashrc, direnv, ...) when convenient — other tooling that reads GITHUB_TOKEN will keep tripping otherwise."
+  unset GITHUB_TOKEN
+  info "gh authenticated (via keychain)"
 elif [ -n "${GITHUB_TOKEN:-}" ]; then
-  warn "GITHUB_TOKEN is set but gh cannot authenticate with it (token may be invalid or lacks required scopes)."
-  warn "Unset it (or replace it with a valid token) and re-run setup:"
+  warn "GITHUB_TOKEN is set but gh cannot authenticate with it, and no keychain credential is available."
+  warn "Either replace GITHUB_TOKEN with a valid token, or unset it and re-run setup so gh can launch the interactive flow:"
   echo "    unset GITHUB_TOKEN && just setup"
   exit 1
 else

--- a/scripts/start-pipeline.sh
+++ b/scripts/start-pipeline.sh
@@ -202,7 +202,21 @@ if [[ "$IS_UPSTREAM_TEMPLATE" == "true" ]]; then
   }
 fi
 
-if ! gh auth status &>/dev/null; then
+# Mirror the setup.sh fallback: if GITHUB_TOKEN is exported but stale, gh
+# auth status fails even when the keychain still has valid credentials. In
+# that case unset the bad env var locally and continue with the keychain,
+# matching `just setup`'s behaviour (see #166 / #168).
+if gh auth status &>/dev/null; then
+  :
+elif [ -n "${GITHUB_TOKEN:-}" ] && env -u GITHUB_TOKEN gh auth status &>/dev/null; then
+  echo "⚠️  GITHUB_TOKEN in your shell is invalid; falling back to gh keychain credentials."
+  echo "⚠️  Fix it in your shell init when convenient — other tools that read GITHUB_TOKEN will keep tripping."
+  unset GITHUB_TOKEN
+elif [ -n "${GITHUB_TOKEN:-}" ]; then
+  echo "❌ GITHUB_TOKEN is set but gh cannot authenticate with it, and no keychain credential is available."
+  echo "   Replace GITHUB_TOKEN with a valid token, or:  unset GITHUB_TOKEN && gh auth login"
+  exit 1
+else
   echo "❌ GitHub CLI is not authenticated"
   echo "   Run: gh auth login"
   exit 1


### PR DESCRIPTION
## Summary

- `setup.sh` / `start-pipeline.sh` / `preflight.sh` の `gh` 認証チェックに **keychain フォールバック**を追加し、3 スクリプトで同じ分岐に揃えた
- `GITHUB_TOKEN` が古くなっていても keychain credential が健在なら、`unset` して継続するよう変更（警告は出す）
- `start-pipeline.sh` と `preflight.sh` は元々**ノーガード**でパイプライン全体が落ちていた挙動を、`setup.sh` 相当の挙動に合わせた

## Background

#167 で `setup.sh` だけは「`GITHUB_TOKEN` 無効なら exit 1」になりましたが、現実には keychain 側に有効な credential が残っているケースが大半（macOS の `gh auth login` 経由など）。毎回手動 `unset` を要求するのはノイズです。`gh` は env var を keychain より優先するため、`env -u GITHUB_TOKEN gh auth status` で keychain 単独の生存確認ができます。

分岐:

```
1) gh auth status                                → そのまま
2) GITHUB_TOKEN set + keychain alive             → unset して継続 (warn)
3) GITHUB_TOKEN set + keychain も無い            → exit 1 (#167 と同じ案内)
4) auth 一切無し                                 → setup.sh: gh auth login / 他: exit 1
```

## Test plan

- [x] `bash -n` 構文チェック × 3 ファイル
- [x] 下流 (`yoshimi-I/gyurikiya_EC`) で同パターンを 1 週間動作確認 (PR #38, #39 経由)
- [ ] 手元で 4 ケース動作確認:
  - [ ] `unset GITHUB_TOKEN` で `just setup` → 既存と同じ挙動
  - [ ] `export GITHUB_TOKEN=invalid` + keychain あり → warn 出してフォールバック・継続
  - [ ] `export GITHUB_TOKEN=invalid` + keychain なし → 既存通り exit 1
  - [ ] `unset` + `gh auth logout` → 既存通り `gh auth login` プロンプト

## 互換性

純粋に追加分岐のみで、既存の正常系・既存の警告系の挙動には変化なし。差分は +40/-8 行。

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@codex review
