### PR TITLE
fix: harden agent pipeline checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: find scripts -name '*.sh' -print0 | xargs -0 -n1 bash -n
 
       - name: Run ShellCheck
-        run: shellcheck -x -P scripts scripts/*.sh scripts/lib/*.sh
+        run: shellcheck -x -P scripts scripts/*.sh scripts/lib/*.sh scripts/tests/*.bash scripts/tests/*.bats
 
       - name: Run BATS unit tests
         run: bats scripts/tests/*.bats

--- a/.github/workflows/promote-main.yml
+++ b/.github/workflows/promote-main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check shell syntax
         run: find scripts -name '*.sh' -print0 | xargs -0 -n1 bash -n
       - name: Run ShellCheck
-        run: shellcheck -x -P scripts scripts/*.sh scripts/lib/*.sh
+        run: shellcheck -x -P scripts scripts/*.sh scripts/lib/*.sh scripts/tests/*.bash scripts/tests/*.bats
       - name: Run BATS unit tests
         run: bats scripts/tests/*.bats
       - name: Run promotion E2E
@@ -48,8 +48,10 @@ jobs:
               npm install
               npm run e2e
             fi
+          elif [ -x ./scripts/check.sh ]; then
+            ./scripts/check.sh
           else
-            echo "::error::No E2E command found. Set repository variable KIRO_E2E_COMMAND, add just e2e, or add package.json script e2e."
+            echo "::error::No E2E command found. Set repository variable KIRO_E2E_COMMAND, add just e2e, add package.json script e2e, or provide ./scripts/check.sh for Bash template repositories."
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ aidlc-docs/
 issue/task.md
 .agent-status/
 .agent-logs/
+.worktrees/

--- a/.kiro/steering/development-rules.md
+++ b/.kiro/steering/development-rules.md
@@ -38,13 +38,13 @@ description: 全タスクに適用されるコアルール
 -->
 
 ```
-# 言語 / フレームワーク: TBD (INCEPTION で決定)
-# パッケージマネージャ: TBD
-# Lint コマンド: TBD
-# Typecheck コマンド: TBD
-# Test コマンド: TBD
-# Build コマンド: TBD
-# Dead code 検出: TBD (任意)
+# 言語 / フレームワーク: Bash scripts + GitHub CLI + zellij orchestration
+# パッケージマネージャ: なし（macOS は Homebrew、Ubuntu CI は apt で shellcheck/bats を導入）
+# Lint コマンド: shellcheck -x -P scripts scripts/*.sh scripts/lib/*.sh scripts/tests/*.bash scripts/tests/*.bats
+# Typecheck コマンド: なし（Bash プロジェクト）
+# Test コマンド: ./scripts/check.sh
+# Build コマンド: なし（スクリプト配布）
+# Dead code 検出: なし（任意）
 # Git: Conventional Commits
 ```
 
@@ -54,10 +54,7 @@ description: 全タスクに適用されるコアルール
 未確定の場合は INCEPTION を先に終わらせること。
 
 ```bash
-# 例: プロジェクト固有設定から読み取ったコマンドを実行
-# $LINT_CMD
-# $TYPECHECK_CMD
-# $TEST_CMD
+./scripts/check.sh
 ```
 
 CI で実行されるチェックは必ずローカルでも通してから push する。CI 失敗 PR は implement エージェントが自身で修正する。

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -13,7 +13,13 @@ if ! command -v shellcheck >/dev/null 2>&1; then
   echo "error: shellcheck is required. Run 'just setup' or install via your package manager." >&2
   exit 1
 fi
-shellcheck -x -P scripts scripts/*.sh scripts/lib/*.sh
+shellcheck -x -P scripts scripts/*.sh scripts/lib/*.sh scripts/tests/*.bash scripts/tests/*.bats
+
+# Repository hygiene.
+if ! git check-ignore -q .worktrees/test; then
+  echo "error: .worktrees/ must be ignored before creating local agent worktrees." >&2
+  exit 1
+fi
 
 # Unit tests.
 if ! command -v bats >/dev/null 2>&1; then

--- a/scripts/lib/github-auth.sh
+++ b/scripts/lib/github-auth.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ "${__GITHUB_AUTH_SH_LOADED:-0}" = "1" ]; then
+  return 0
+fi
+__GITHUB_AUTH_SH_LOADED=1
+
+gh_auth_status() {
+  gh auth status >/dev/null 2>&1
+}
+
+gh_auth_status_without_env_token() {
+  env -u GITHUB_TOKEN gh auth status >/dev/null 2>&1
+}
+
+recover_gh_auth_from_env_token() {
+  [ -n "${GITHUB_TOKEN:-}" ] || return 1
+  gh_auth_status_without_env_token || return 1
+  unset GITHUB_TOKEN
+}

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -6,6 +6,10 @@ STABLE_BRANCH="${AI_STABLE_BRANCH:-${KIRO_STABLE_BRANCH:-main}}"
 failures=0
 warnings=0
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/github-auth.sh
+source "${SCRIPT_DIR}/lib/github-auth.sh"
+
 ok() { printf '  \033[32m✔\033[0m %s\n' "$1"; }
 warn() { warnings=$((warnings + 1)); printf '  \033[33m⚠\033[0m %s\n' "$1"; }
 fail() { failures=$((failures + 1)); printf '  \033[31m✘\033[0m %s\n' "$1"; }
@@ -52,7 +56,10 @@ if command -v zellij >/dev/null 2>&1; then
   fi
 fi
 
-if gh auth status >/dev/null 2>&1; then
+if gh_auth_status; then
+  ok "gh authenticated"
+elif recover_gh_auth_from_env_token; then
+  warn "GITHUB_TOKEN is set but invalid; using keychain gh credentials for this preflight run"
   ok "gh authenticated"
 else
   fail "gh is not authenticated. Run: gh auth login"
@@ -112,8 +119,10 @@ elif [ -f justfile ] && command -v just >/dev/null 2>&1 && just --list 2>/dev/nu
   ok "just e2e detected"
 elif [ -f package.json ] && jq -e '.scripts.e2e' package.json >/dev/null 2>&1; then
   ok "package.json e2e script detected"
+elif [ -x ./scripts/check.sh ]; then
+  ok "Bash template verification detected (./scripts/check.sh)"
 else
-  warn "no E2E command detected; main promotion will fail until AI_E2E_COMMAND (or legacy KIRO_E2E_COMMAND), just e2e, or package.json e2e is configured"
+  warn "no E2E command detected; main promotion will fail until AI_E2E_COMMAND (or legacy KIRO_E2E_COMMAND), just e2e, package.json e2e, or ./scripts/check.sh is configured"
 fi
 
 echo ""

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -37,6 +37,10 @@ version_ge() {
     }'
 }
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/github-auth.sh
+source "${SCRIPT_DIR}/lib/github-auth.sh"
+
 # ── Detect package manager ──
 if command -v brew &>/dev/null; then
   PKG="brew"
@@ -106,7 +110,10 @@ fi
 # that combination explicitly so the user gets a clear instruction instead
 # of an opaque "first clear the value from the environment" message that
 # appears mid-prompt and then exits 1.
-if gh auth status &>/dev/null; then
+if gh_auth_status; then
+  info "gh authenticated"
+elif recover_gh_auth_from_env_token; then
+  warn "GITHUB_TOKEN is set but gh cannot authenticate with it; using keychain gh credentials for this setup run."
   info "gh authenticated"
 elif [ -n "${GITHUB_TOKEN:-}" ]; then
   warn "GITHUB_TOKEN is set but gh cannot authenticate with it (token may be invalid or lacks required scopes)."

--- a/scripts/start-pipeline.sh
+++ b/scripts/start-pipeline.sh
@@ -18,6 +18,8 @@ export KIRO_STABLE_BRANCH="$STABLE_BRANCH"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/runner.sh
 source "${SCRIPT_DIR}/lib/runner.sh"
+# shellcheck source=lib/github-auth.sh
+source "${SCRIPT_DIR}/lib/github-auth.sh"
 
 # ── Preflight ──
 RUNNER_BIN="$(ai_runner_binary)"
@@ -202,7 +204,11 @@ if [[ "$IS_UPSTREAM_TEMPLATE" == "true" ]]; then
   }
 fi
 
-if ! gh auth status &>/dev/null; then
+if gh_auth_status; then
+  :
+elif recover_gh_auth_from_env_token; then
+  echo "⚠️  GITHUB_TOKEN is set but invalid; using keychain gh credentials for this pipeline run."
+else
   echo "❌ GitHub CLI is not authenticated"
   echo "   Run: gh auth login"
   exit 1

--- a/scripts/tests/common.bats
+++ b/scripts/tests/common.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC1091
 # Tests for scripts/lib/common.sh
 
 load helpers

--- a/scripts/tests/github.bats
+++ b/scripts/tests/github.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC1091,SC2030,SC2031
 # Tests for scripts/lib/github.sh normalize_prs_json — the heart of the PR
 # state machine. Every downstream decision (review pane vs fix-review pane,
 # dashboard colour, skip reasons) depends on this normalization, so it gets

--- a/scripts/tests/github_auth.bats
+++ b/scripts/tests/github_auth.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
+# Tests for GitHub CLI authentication recovery helpers.
+
+load helpers
+
+setup() {
+  ts_setup
+  mkdir -p "${TS_ROOT}/bin"
+  PATH="${TS_ROOT}/bin:/usr/bin:/bin"
+  export PATH
+}
+
+teardown() {
+  ts_teardown
+}
+
+write_fake_gh_env_token_bad_keychain_good() {
+  cat > "${TS_ROOT}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [ "$1 $2" = "auth status" ]; then
+  [ -z "${GITHUB_TOKEN:-}" ]
+  exit $?
+fi
+exit 1
+SH
+  chmod +x "${TS_ROOT}/bin/gh"
+}
+
+write_fake_gh_all_auth_bad() {
+  cat > "${TS_ROOT}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [ "$1 $2" = "auth status" ]; then
+  exit 1
+fi
+exit 1
+SH
+  chmod +x "${TS_ROOT}/bin/gh"
+}
+
+@test "recover_gh_auth_from_env_token unsets invalid GITHUB_TOKEN when keychain auth works" {
+  write_fake_gh_env_token_bad_keychain_good
+  export GITHUB_TOKEN=bad-token
+  # shellcheck disable=SC1091
+  source "${TS_LIB_DIR}/github-auth.sh"
+
+  run bash -c 'source "$1"; export GITHUB_TOKEN=bad-token; recover_gh_auth_from_env_token; [ -z "${GITHUB_TOKEN:-}" ]' _ "${TS_LIB_DIR}/github-auth.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "recover_gh_auth_from_env_token fails when keychain auth also fails" {
+  write_fake_gh_all_auth_bad
+  export GITHUB_TOKEN=bad-token
+  # shellcheck disable=SC1091
+  source "${TS_LIB_DIR}/github-auth.sh"
+
+  run recover_gh_auth_from_env_token
+  [ "$status" -ne 0 ]
+  [ "${GITHUB_TOKEN}" = "bad-token" ]
+}

--- a/scripts/tests/helpers.bash
+++ b/scripts/tests/helpers.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 # Shared helpers for BATS tests.
 #
 # Usage inside a .bats file:

--- a/scripts/tests/panes.bats
+++ b/scripts/tests/panes.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC1091
 # Tests for scripts/lib/panes.sh pure registry operations.
 #
 # We test the parts that don't touch zellij: registry parsing, counting,

--- a/scripts/tests/planner.bats
+++ b/scripts/tests/planner.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC1091,SC2034
 # Tests for scripts/lib/planner.sh pure functions.
 #
 # We isolate the pure JSON/shape functions from the ones that call out to

--- a/scripts/tests/preflight.bats
+++ b/scripts/tests/preflight.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2016
+# Tests for scripts/preflight.sh runner-aware prerequisite checks.
+
+load helpers
+
+setup() {
+  ts_setup
+  mkdir -p "${TS_ROOT}/bin"
+  PATH="${TS_ROOT}/bin:/usr/bin:/bin"
+  export PATH
+  write_fake_tools
+}
+
+teardown() {
+  ts_teardown
+}
+
+write_executable() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" > "$path"
+  chmod +x "$path"
+}
+
+write_fake_tools() {
+  write_executable "${TS_ROOT}/bin/claude" \
+    '#!/usr/bin/env bash' \
+    'exit 0'
+
+  write_executable "${TS_ROOT}/bin/jq" \
+    '#!/usr/bin/env bash' \
+    'exit 0'
+
+  write_executable "${TS_ROOT}/bin/zellij" \
+    '#!/usr/bin/env bash' \
+    'if [ "${1:-}" = "--version" ]; then echo "zellij 0.44.3"; exit 0; fi' \
+    'exit 0'
+
+  write_executable "${TS_ROOT}/bin/git" \
+    '#!/usr/bin/env bash' \
+    'case "$*" in' \
+    '  "remote get-url origin") exit 0 ;;' \
+    '  "ls-remote --exit-code --heads origin develop") exit 1 ;;' \
+    'esac' \
+    'exit 0'
+
+  write_executable "${TS_ROOT}/bin/gh" \
+    '#!/usr/bin/env bash' \
+    'case "$1 $2" in' \
+    '  "auth status") exit 0 ;;' \
+    '  "repo view")' \
+    '    if [[ "$*" == *"defaultBranchRef"* ]]; then echo "main"; else echo "{\"nameWithOwner\":\"owner/repo\"}"; fi' \
+    '    exit 0 ;;' \
+    '  "secret list") echo "KIRO_API_KEY"; exit 0 ;;' \
+    '  "workflow view") exit 0 ;;' \
+    '  "api repos/{owner}/{repo}/actions/permissions/workflow") echo "write"; exit 0 ;;' \
+    'esac' \
+    'exit 0'
+}
+
+@test "preflight with AI_RUNNER=claude does not require kiro-cli" {
+  run env AI_RUNNER=claude bash "${TS_REPO_ROOT}/scripts/preflight.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"claude found"* ]]
+  [[ "$output" != *"kiro-cli is required"* ]]
+}
+
+@test "preflight with AI_RUNNER=kiro requires kiro-cli" {
+  run env AI_RUNNER=kiro bash "${TS_REPO_ROOT}/scripts/preflight.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"kiro-cli is required"* ]]
+}


### PR DESCRIPTION
## Summary
- Recover from invalid GITHUB_TOKEN when keychain gh auth still works across setup, preflight, and start-pipeline.
- Add ShellCheck coverage for BATS/helper tests and enforce .worktrees/ ignore hygiene in local checks and CI.
- Add runner-aware preflight regression tests and replace TBD steering settings with the actual Bash verification commands.
- Allow promotion validation to use ./scripts/check.sh for this Bash template repository when no app E2E command is configured.

## Root Cause
- gh prefers GITHUB_TOKEN over keychain credentials, so a stale env token could block workflows even when keychain auth was valid.
- The verification gate did not include test files in ShellCheck, and the preferred .worktrees/ path was not ignored.
- Project-specific steering settings still contained template TBD values.
- promote-main.yml required an application E2E command even for this Bash template repository, causing validate-promotion to fail after CI passed.

## Test Plan
- [x] ./scripts/check.sh (69 tests)
- [x] AI_RUNNER=claude ./scripts/preflight.sh

Closes #168
Closes #171
Closes #172
Closes #173
Closes #174
Closes #176