### PR TITLE
feat: position as loop engineering runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,16 +5,17 @@ The orchestrator starts minimal and spawns additional zellij panes on
 demand based on open issues, PRs, and post-merge state — it is **not** a
 fixed "N agent" pool.
 
-This file is also loaded by Claude Code (via the `CLAUDE.md` symlink), so
-the same project rules apply whether the pipeline is driven by Kiro CLI
-or Claude Code. Pick one with `AI_RUNNER=kiro` (default) or
-`AI_RUNNER=claude`; the legacy `KIRO_AI_RUNNER` name is still honoured.
+This file is also loaded by Claude Code (via the `CLAUDE.md` symlink) and
+Codex (as `AGENTS.md`), so the same project rules apply whether the pipeline
+is driven by Kiro CLI, Claude Code, or Codex CLI. Pick one with
+`AI_RUNNER=kiro` (default), `AI_RUNNER=claude`, or `AI_RUNNER=codex`; the
+legacy `KIRO_AI_RUNNER` name is still honoured.
 
 Slash commands live in `.kiro/prompts/` and are mirrored at
 `.claude/commands/`; skills live in `.kiro/skills/` and are mirrored at
 `.claude/skills/`. The `.kiro/` paths are kept as the canonical location
-because kiro-cli reads them natively — both runners resolve the same
-content through the mirror.
+because kiro-cli reads them natively — supported runners resolve the same
+project guidance through their native surfaces.
 
 ## First interaction
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 # 🏭 ai-engineer-teams
 
-**Auto-scaling agent development pipeline**
-**powered by [Kiro CLI](https://kiro.dev/docs/cli/) × [zellij](https://zellij.dev/)**
+**Loop engineering runtime for autonomous AI coding teams**
+**powered by GitHub Issues × Codex / Claude Code / Kiro × zellij**
 
 issue → implementation → review → merge → E2E verification — fully automated.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Codex CLI](https://img.shields.io/badge/Codex_CLI-compatible-black.svg)](https://developers.openai.com/codex/cli)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-compatible-orange.svg)](https://docs.claude.com/en/docs/claude-code/quickstart)
 [![Kiro CLI](https://img.shields.io/badge/Kiro_CLI-compatible-purple.svg)](https://kiro.dev/docs/cli/)
 [![CI + Kiro Review](https://img.shields.io/badge/CI-Kiro_Review-green.svg)](.github/workflows/kiro-review.yml)
 
@@ -16,6 +18,39 @@ issue → implementation → review → merge → E2E verification — fully aut
 </div>
 
 ---
+
+## Why This Exists
+
+Most AI coding tools still assume a human keeps prompting: "pick the next
+issue", "fix the review", "rerun tests", "merge it", "check production".
+Loop engineering moves that outer loop into software.
+
+`ai-engineer-teams` turns a repository into a repeatable agent loop:
+
+1. GitHub Issues define work.
+2. The orchestrator observes issues, PRs, CI, reviews, and merge state.
+3. zellij panes are spawned only when a role is needed.
+4. Codex, Claude Code, or Kiro performs the work.
+5. CI and review results feed back into the next loop.
+
+The goal is not "N agents running forever". The goal is a small control plane
+that keeps prompting the right agent at the right time.
+
+## What Makes It Different
+
+| Approach | What it gives you | What is missing |
+|---|---|---|
+| One-shot prompting | Fast local edits | You still drive every next step |
+| Claude/Codex hooks only | Useful guardrails | No GitHub issue/PR control loop |
+| Simple shell loop | Easy to understand | No role separation, review state, or merge gates |
+| Generic loop-engineering scaffold | Concepts and starter patterns | Usually not a full GitHub delivery pipeline |
+| **ai-engineer-teams** | Issue queue, dynamic panes, role-specific prompts, CI review, fix-review, E2E promotion | Requires GitHub CLI, zellij, and one supported AI runner |
+
+## Demo And Launch Kit
+
+- [30-second terminal demo script](docs/DEMO.md)
+- [Launch copy for X, Hacker News, Reddit, Zenn, and Qiita](docs/LAUNCH.md)
+- Positioning: **Loop engineering runtime for GitHub issue-driven AI coding teams**
 
 ## Quick Start
 
@@ -114,6 +149,26 @@ just start (./scripts/start-pipeline.sh)
 
 ---
 
+## 🤖 Supported AI Runners
+
+The local loop can be driven by any of these CLIs:
+
+| Runner | `AI_RUNNER` | Non-interactive command | Best fit |
+|---|---|---|---|
+| [Codex CLI](https://developers.openai.com/codex/cli) | `codex` | `codex exec` | Codex-first terminal automation |
+| [Claude Code](https://docs.claude.com/en/docs/claude-code/quickstart) | `claude` | `claude --print` | Claude Code projects and skills |
+| [Kiro CLI](https://kiro.dev/docs/cli/) | `kiro` | `kiro-cli chat --no-interactive` | Kiro-native prompts and review action |
+
+```bash
+AI_RUNNER=codex just start
+AI_RUNNER=claude just start
+AI_RUNNER=kiro just start
+```
+
+Codex reads the repository-level `AGENTS.md` guidance directly. Claude Code
+uses the `CLAUDE.md` symlink, and Kiro uses the canonical `.kiro/` prompts and
+skills.
+
 ## 🤖 CI Reviews (Kiro and Claude Code)
 
 Two parallel review workflows ship out of the box. Either or both can run;
@@ -190,21 +245,25 @@ Orchestrator (starts with 1 agent, scales as needed)
 
 | Tool | Install | Required |
 |------|---------|:---:|
-| [Kiro CLI](https://kiro.dev/docs/cli/) | See [downloads](https://kiro.dev/downloads/) | ✅ (one of the two) |
-| [Claude Code](https://docs.claude.com/en/docs/claude-code/quickstart) | `npm i -g @anthropic-ai/claude-code` | ✅ (one of the two) |
+| [Codex CLI](https://developers.openai.com/codex/cli) | See Codex CLI quickstart | ✅ (one of the three) |
+| [Kiro CLI](https://kiro.dev/docs/cli/) | See [downloads](https://kiro.dev/downloads/) | ✅ (one of the three) |
+| [Claude Code](https://docs.claude.com/en/docs/claude-code/quickstart) | `npm i -g @anthropic-ai/claude-code` | ✅ (one of the three) |
 | [zellij](https://zellij.dev/) | `brew install zellij` | ✅ 0.44.1+ |
 | [GitHub CLI](https://cli.github.com/) | `brew install gh` → `gh auth login` | ✅ |
 | [gum](https://github.com/charmbracelet/gum) | `brew install gum` | ✅ (for control panel) |
 | [jq](https://jqlang.github.io/jq/) | `brew install jq` | ✅ |
 | [just](https://just.systems/) | `brew install just` | Optional |
 
-The pipeline can be driven by either runner; pick one with the
-`AI_RUNNER` environment variable (default `kiro`). The legacy
+The pipeline can be driven by Codex, Claude Code, or Kiro CLI; pick one with
+the `AI_RUNNER` environment variable (default `kiro`). The legacy
 `KIRO_AI_RUNNER` name is still honoured.
 
 ```bash
 # Default: Kiro CLI
 just start
+
+# Drive the same pipeline with Codex CLI
+AI_RUNNER=codex just start
 
 # Drive the same pipeline with Claude Code
 AI_RUNNER=claude just start
@@ -217,7 +276,7 @@ backward compatibility:
 
 | Canonical name | Legacy alias | Purpose |
 |---|---|---|
-| `AI_RUNNER` | `KIRO_AI_RUNNER` | `kiro` (default) or `claude` |
+| `AI_RUNNER` | `KIRO_AI_RUNNER` | `kiro` (default), `claude`, or `codex` |
 | `AI_INTEGRATION_BRANCH` | `KIRO_INTEGRATION_BRANCH` | feature PR target (default `develop`) |
 | `AI_STABLE_BRANCH` | `KIRO_STABLE_BRANCH` | promotion target (default `main`) |
 | `AI_E2E_COMMAND` | `KIRO_E2E_COMMAND` | command run by `watch-main` for E2E gating |
@@ -230,7 +289,8 @@ backward compatibility:
 - `.kiro/skills/`  ←→ `.claude/skills/`  (symlink)
 - `AGENTS.md`      ←→ `CLAUDE.md`         (symlink)
 
-so editing the canonical `.kiro/` copy keeps both runners in sync.
+so editing the canonical `.kiro/` copy keeps Kiro and Claude Code in sync,
+while Codex loads the repository rules from `AGENTS.md`.
 
 zellij **0.44.1 or newer is required**. The orchestrator depends on the newer CLI automation APIs: `list-panes --json`, pane IDs, `--tab-id`, and `--close-on-exit`. Older versions such as `0.43.1` cannot run the dynamic pane lifecycle correctly.
 
@@ -282,9 +342,10 @@ The orchestrator pane refreshes on a fixed tick (`ORCH_TICK_INTERVAL`, default `
 | `delivery-pipeline` | Delivery automation |
 | `inception` | INCEPTION workflow |
 
-All skills are available as `/slash-commands` in the interactive Kiro tab,
-and as Claude Code skills under `.claude/skills/` when running with
-`AI_RUNNER=claude`.
+Skills are available as `/slash-commands` in the interactive Kiro tab and as
+Claude Code skills under `.claude/skills/` when running with
+`AI_RUNNER=claude`. Codex uses the shared `AGENTS.md` operating rules and can
+run the same issue-driven loop with `AI_RUNNER=codex`.
 
 ---
 
@@ -318,7 +379,7 @@ scripts/
 ├── start-pipeline.sh              # Launcher (INCEPTION → pipeline)
 ├── orchestrator.sh                # Dynamic role allocation
 ├── agent.sh                       # Agent loop wrapper
-├── lib/runner.sh                  # AI runner abstraction (kiro / claude)
+├── lib/runner.sh                  # AI runner abstraction (kiro / claude / codex)
 ├── control-panel.sh               # TUI control panel (gum)
 ├── dashboard.sh                   # Status dashboard
 └── pipeline.kdl                   # zellij layout

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,58 @@
+# 30-Second Demo Script
+
+Use this when recording a GIF, asciinema, or terminal video for the README,
+X, Hacker News, Reddit, Zenn, or Qiita.
+
+## Setup
+
+```bash
+git clone https://github.com/yoshimi-I/ai-engineer-teams.git loop-demo
+cd loop-demo
+just setup
+AI_RUNNER=codex just preflight
+```
+
+For the cleanest recording, use a test repository with one small issue already
+open, for example:
+
+```text
+feat: add a health check command
+```
+
+## Recording Flow
+
+```bash
+AI_RUNNER=codex just start
+```
+
+Capture these beats:
+
+1. Preflight validates GitHub, zellij, runner, ShellCheck, and BATS.
+2. INCEPTION or existing artifacts define the issue queue.
+3. The orchestrator starts with minimal panes.
+4. A ready GitHub issue appears.
+5. An `implement` pane is spawned.
+6. The agent opens a PR.
+7. CI and review state feed back into the next loop.
+
+## Suggested Voiceover
+
+```text
+This is ai-engineer-teams: a loop engineering runtime for GitHub issue-driven
+AI coding teams. GitHub issues become the queue, zellij panes become workers,
+and Codex, Claude Code, or Kiro performs the work. The orchestrator watches
+issues, PRs, reviews, CI, and merge state, then prompts the right agent at the
+right time.
+```
+
+## One-Screen Terminal Mock
+
+```text
+GitHub issue #42 ready
+  -> orchestrator launches implement-1
+  -> Codex works in a zellij pane
+  -> PR #43 opened
+  -> CI/review pass
+  -> merge manager promotes the change
+  -> E2E/watch-main closes the loop
+```

--- a/docs/LAUNCH.md
+++ b/docs/LAUNCH.md
@@ -1,0 +1,78 @@
+# Launch Kit
+
+## Positioning
+
+`ai-engineer-teams` is a loop engineering runtime for GitHub issue-driven AI
+coding teams.
+
+It turns this:
+
+```text
+Human prompts agent -> agent edits code -> human checks PR -> human prompts again
+```
+
+into this:
+
+```text
+GitHub issue -> orchestrator -> Codex/Claude/Kiro pane -> PR -> CI/review -> next loop
+```
+
+## Short Description
+
+Loop engineering runtime for autonomous AI coding teams: GitHub Issues become
+the queue, zellij panes become workers, and Codex, Claude Code, or Kiro closes
+the issue-to-PR-to-review loop.
+
+## X / Twitter
+
+```text
+I built ai-engineer-teams: a loop engineering runtime for GitHub issue-driven AI coding teams.
+
+GitHub Issues -> zellij workers -> Codex/Claude/Kiro -> PR -> CI/review -> next loop.
+
+It is not "N agents forever"; it starts minimal and spawns only the role needed next.
+
+https://github.com/yoshimi-I/ai-engineer-teams
+```
+
+## Hacker News
+
+```text
+Show HN: ai-engineer-teams, a loop engineering runtime for AI coding agents
+
+I built a small shell/zellij/GitHub control plane that turns GitHub issues into
+an autonomous coding loop. It watches issues, PRs, review decisions, CI, and
+merge state, then spawns role-specific agent panes only when needed.
+
+It supports Codex CLI, Claude Code, and Kiro CLI through AI_RUNNER.
+```
+
+## Reddit
+
+```text
+I made a loop engineering runtime for coding agents.
+
+Instead of manually prompting an agent after every step, GitHub issues become
+the queue and a zellij orchestrator spawns implement/review/fix/E2E panes as
+the repo state changes. It supports Codex CLI, Claude Code, and Kiro CLI.
+```
+
+## Zenn / Qiita Title Ideas
+
+- GitHub issue を AI agent team の work queue にする loop engineering runtime を作った
+- Codex / Claude Code / Kiro を zellij で動的に束ねる agent loop 実装
+- 「agent に毎回 prompt する」をやめて、prompt する仕組みを作る
+
+## GitHub Metadata
+
+Description:
+
+```text
+Loop engineering runtime for GitHub issue-driven AI coding teams: Codex, Claude Code, Kiro, zellij.
+```
+
+Topics:
+
+```text
+loop-engineering, ai-agents, coding-agents, codex, codex-cli, claude-code, kiro, zellij, github-automation, agentic-workflow
+```

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -2,12 +2,14 @@
 
 # 🏭 ai-engineer-teams
 
-**動的スケーリング型エージェント開発パイプライン**
-**[Kiro CLI](https://kiro.dev/docs/cli/) × [zellij](https://zellij.dev/)**
+**GitHub issue 駆動の AI coding team を作る loop engineering runtime**
+**Codex / Claude Code / Kiro × zellij**
 
 issue → 実装 → レビュー → マージ → E2E検証を全自動化。
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../LICENSE)
+[![Codex CLI](https://img.shields.io/badge/Codex_CLI-compatible-black.svg)](https://developers.openai.com/codex/cli)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-compatible-orange.svg)](https://docs.claude.com/en/docs/claude-code/quickstart)
 [![Kiro CLI](https://img.shields.io/badge/Kiro_CLI-compatible-purple.svg)](https://kiro.dev/docs/cli/)
 [![CI + Kiro Review](https://img.shields.io/badge/CI-Kiro_Review-green.svg)](../.github/workflows/kiro-review.yml)
 
@@ -16,6 +18,25 @@ issue → 実装 → レビュー → マージ → E2E検証を全自動化。
 </div>
 
 ---
+
+## これは何か
+
+`ai-engineer-teams` は、毎回人間が agent に「次はこの issue」「レビューを直して」
+「テストを回して」と指示する代わりに、その外側のループをソフトウェア化します。
+
+1. GitHub issue を work queue にする
+2. orchestrator が issue / PR / CI / review / merge 状態を観測する
+3. 必要な role だけ zellij pane として起動する
+4. Codex / Claude Code / Kiro が実装・修正・検証を行う
+5. 結果を次の loop に戻す
+
+「N 個の agent を常時走らせる」ためのツールではありません。repo の状態を見て、
+次に必要な agent だけを prompt する loop engineering runtime です。
+
+## Demo / Launch
+
+- [30秒デモ台本](DEMO.md)
+- [公開告知用 launch kit](LAUNCH.md)
 
 ## クイックスタート
 
@@ -156,10 +177,20 @@ Orchestrator（最小構成で起動 → 必要に応じてスケール）
 
 | ツール | インストール | 必須 |
 |--------|------------|------|
-| [Kiro CLI](https://kiro.dev/docs/cli/) | [ダウンロード](https://kiro.dev/downloads/) | ✅ |
+| [Codex CLI](https://developers.openai.com/codex/cli) | Codex CLI quickstart | ✅（3つのうち1つ） |
+| [Kiro CLI](https://kiro.dev/docs/cli/) | [ダウンロード](https://kiro.dev/downloads/) | ✅（3つのうち1つ） |
+| [Claude Code](https://docs.claude.com/en/docs/claude-code/quickstart) | `npm i -g @anthropic-ai/claude-code` | ✅（3つのうち1つ） |
 | [zellij](https://zellij.dev/) | `brew install zellij` | ✅ 0.44.1+ |
 | [GitHub CLI](https://cli.github.com/) | `brew install gh` → `gh auth login` | ✅ |
 | [just](https://just.systems/) | `brew install just` | 任意（GitLab切替用） |
+
+runner は `AI_RUNNER` で切り替えます。
+
+```bash
+AI_RUNNER=codex just start
+AI_RUNNER=claude just start
+AI_RUNNER=kiro just start
+```
 
 zellij は **0.44.1 以上が必須**です。オーケストレーターは新しい CLI automation API（`list-panes --json`、pane ID、`--tab-id`、`--close-on-exit`）に依存しています。`0.43.1` など古いバージョンでは、必要な時だけ pane を作り、完了後に閉じる動的ライフサイクルが正しく動きません。
 

--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Usage: ./scripts/agent.sh <prompt-name>
-# Runs an AI agent (kiro-cli or Claude Code, selected by AI_RUNNER /
+# Runs an AI agent (Kiro CLI, Claude Code, or Codex CLI, selected by AI_RUNNER /
 # KIRO_AI_RUNNER) in a loop, feeding it the specified prompt.
 # Agents that depend on issues/PRs will wait until work is available.
 

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # AI runner abstraction.
 #
-# The pipeline can be driven by either Kiro CLI or Claude Code, selected via
+# The pipeline can be driven by Kiro CLI, Claude Code, or Codex CLI, selected via
 # the AI_RUNNER environment variable (legacy KIRO_AI_RUNNER is also honoured
 # for backward compatibility):
 #
 #   AI_RUNNER=kiro     (default) — uses `kiro-cli`
 #   AI_RUNNER=claude             — uses `claude` (Claude Code CLI)
+#   AI_RUNNER=codex              — uses `codex` (Codex CLI)
 #
 # Two entry points are exposed:
 #
@@ -18,7 +19,7 @@
 #                                 INCEPTION launcher in start-pipeline.sh.
 #
 # Each runner has a different surface for these two modes; this file keeps
-# every kiro-cli vs claude difference in one place so the rest of the
+# every runner-specific difference in one place so the rest of the
 # pipeline does not branch on the runner.
 
 if [ "${__AI_RUNNER_SH_LOADED:-0}" = "1" ]; then
@@ -36,6 +37,7 @@ ai_runner_binary() {
   case "$AI_RUNNER" in
     kiro)   echo "kiro-cli" ;;
     claude) echo "claude"   ;;
+    codex)  echo "codex"    ;;
     *)      echo "kiro-cli" ;;
   esac
 }
@@ -47,6 +49,12 @@ ai_runner_available() {
 ai_run_oneshot() {
   local prompt="$1"
   case "$AI_RUNNER" in
+    codex)
+      codex exec \
+        --ask-for-approval never \
+        --sandbox danger-full-access \
+        "$prompt"
+      ;;
     claude)
       # `claude --print` is Claude Code's headless mode. We bypass permission
       # prompts because agents run unattended in zellij panes; the equivalent
@@ -71,6 +79,13 @@ ai_run_oneshot() {
 ai_run_interactive() {
   local prompt="$1"
   case "$AI_RUNNER" in
+    codex)
+      if [ -n "$prompt" ]; then
+        codex "$prompt"
+      else
+        codex
+      fi
+      ;;
     claude)
       # In interactive mode we want the user to see the conversation. We do
       # NOT pass --permission-mode here so Claude Code uses the project's

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -36,6 +36,7 @@ AI_RUNNER="${AI_RUNNER:-${KIRO_AI_RUNNER:-kiro}}"
 case "$AI_RUNNER" in
   kiro)   RUNNER_BIN="kiro-cli" ;;
   claude) RUNNER_BIN="claude"   ;;
+  codex)  RUNNER_BIN="codex"    ;;
   *)      RUNNER_BIN="kiro-cli" ;;
 esac
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install prerequisites for the ai-engineer-teams pipeline.
 #
-# This script ONLY installs tools (one of kiro-cli or claude, plus zellij,
+# This script ONLY installs tools (one of kiro-cli, claude, or codex, plus zellij,
 # gh, gum, jq, shellcheck, bats-core, fswatch). It never removes user files.
 # Template cleanup is
 # owned by scripts/start-pipeline.sh (which detects the upstream template
@@ -53,9 +53,9 @@ else
 fi
 
 # ── AI runner CLIs ──
-# We support both Kiro CLI and Claude Code; users pick one via
+# We support Kiro CLI, Claude Code, and Codex CLI; users pick one via
 # AI_RUNNER (default kiro). KIRO_AI_RUNNER is honoured for backward
-# compatibility. At least one of the two CLIs must be installed.
+# compatibility.
 AI_RUNNER="${AI_RUNNER:-${KIRO_AI_RUNNER:-kiro}}"
 
 if command -v kiro-cli &>/dev/null; then
@@ -68,6 +68,12 @@ if command -v claude &>/dev/null; then
   info "claude (Claude Code) already installed"
 elif [[ "$AI_RUNNER" == "claude" ]]; then
   warn "claude not found (AI_RUNNER=claude). Install: https://docs.claude.com/en/docs/claude-code/quickstart"
+fi
+
+if command -v codex &>/dev/null; then
+  info "codex (Codex CLI) already installed"
+elif [[ "$AI_RUNNER" == "codex" ]]; then
+  warn "codex not found (AI_RUNNER=codex). Install: https://developers.openai.com/codex/cli"
 fi
 
 # ── zellij ──

--- a/scripts/tests/preflight.bats
+++ b/scripts/tests/preflight.bats
@@ -28,6 +28,10 @@ write_fake_tools() {
     '#!/usr/bin/env bash' \
     'exit 0'
 
+  write_executable "${TS_ROOT}/bin/codex" \
+    '#!/usr/bin/env bash' \
+    'exit 0'
+
   write_executable "${TS_ROOT}/bin/jq" \
     '#!/usr/bin/env bash' \
     'exit 0'
@@ -70,4 +74,11 @@ write_fake_tools() {
   run env AI_RUNNER=kiro bash "${TS_REPO_ROOT}/scripts/preflight.sh"
   [ "$status" -ne 0 ]
   [[ "$output" == *"kiro-cli is required"* ]]
+}
+
+@test "preflight with AI_RUNNER=codex uses Codex CLI" {
+  run env AI_RUNNER=codex bash "${TS_REPO_ROOT}/scripts/preflight.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"codex found"* ]]
+  [[ "$output" != *"kiro-cli is required"* ]]
 }

--- a/scripts/tests/runner.bats
+++ b/scripts/tests/runner.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091,SC2016
+# Tests for scripts/lib/runner.sh.
+
+load helpers
+
+setup() {
+  ts_setup
+}
+
+teardown() {
+  ts_teardown
+}
+
+source_runner_with() {
+  local runner="$1"
+  AI_RUNNER="$runner" KIRO_AI_RUNNER="" bash -c 'source "$1"; ai_runner_binary' _ "${TS_LIB_DIR}/runner.sh"
+}
+
+@test "ai_runner_binary maps codex to Codex CLI" {
+  run source_runner_with codex
+  [ "$status" -eq 0 ]
+  [ "$output" = "codex" ]
+}
+
+@test "ai_run_oneshot uses codex exec for Codex CLI" {
+  mkdir -p "${TS_ROOT}/bin"
+  cat > "${TS_ROOT}/bin/codex" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$CODEX_ARGS_FILE"
+SH
+  chmod +x "${TS_ROOT}/bin/codex"
+  export PATH="${TS_ROOT}/bin:${PATH}"
+  export CODEX_ARGS_FILE="${TS_ROOT}/codex-args.txt"
+
+  run env AI_RUNNER=codex bash -c 'source "$1"; ai_run_oneshot "build the thing"' _ "${TS_LIB_DIR}/runner.sh"
+  [ "$status" -eq 0 ]
+  run cat "$CODEX_ARGS_FILE"
+  [ "$output" = "exec --ask-for-approval never --sandbox danger-full-access build the thing" ]
+}


### PR DESCRIPTION
## Summary
- Reposition the README around loop engineering instead of Kiro templates.
- Add Codex CLI as a supported AI runner via AI_RUNNER=codex.
- Add demo and launch-kit docs for public distribution.
- Update Japanese docs and AGENTS.md to describe Codex / Claude Code / Kiro support.

## Test Plan
- [x] ./scripts/check.sh (72 tests)
- [x] AI_RUNNER=codex ./scripts/preflight.sh

Closes #177